### PR TITLE
Sync schema to data

### DIFF
--- a/mapping/requirements_officejs.json
+++ b/mapping/requirements_officejs.json
@@ -1247,12 +1247,12 @@
 					"supportedProductVersions": [
 						{
 							"from": {
-								"build": "15.0.3612.1010" // Office 2013 Preview	
+								"build": "15.0.3612.1010"
 							}
 						},
 						{
 							"from": {
-								"build": "16.0.3629.1006" // Office 2016 Beta
+								"build": "16.0.3629.1006"
 							}
 						}
 					],
@@ -4155,12 +4155,12 @@
 					"supportedProductVersions": [
 						{
 							"from": {
-								"build": "15.0.3612.1010" // Office 2013 Preview	
+								"build": "15.0.3612.1010"
 							}
 						},
 						{
 							"from": {
-								"build": "16.0.3629.1006" // Office 2016 Beta
+								"build": "16.0.3629.1006"
 							}
 						}
 					],
@@ -5055,12 +5055,12 @@
 					"supportedProductVersions": [
 						{
 							"from": {
-								"build": "15.0.3612.1010" // Office 2013 Preview	
+								"build": "15.0.3612.1010"
 							}
 						},
 						{
 							"from": {
-								"build": "16.0.3629.1006" // Office 2016 Beta
+								"build": "16.0.3629.1006"
 							}
 						}
 					],
@@ -5562,7 +5562,7 @@
 						},
 						{
 							"from": {
-								"build": "16.0.3629.1006" // Office 2016 Beta
+								"build": "16.0.3629.1006"
 							}
 						}
 					],

--- a/mapping/requirements_officejs.json
+++ b/mapping/requirements_officejs.json
@@ -232,7 +232,7 @@
 								}
 							],
 							"availability": "GA"
-						}						
+						}
 					],
 					"supportedMethods": [
 						{
@@ -842,7 +842,7 @@
 								}
 							],
 							"availability": "GA"
-						}						
+						}
 					],
 					"supportedMethods": [
 						{
@@ -1244,6 +1244,18 @@
 						"ContentApp",
 						"TaskPaneApp"
 					],
+					"supportedProductVersions": [
+						{
+							"from": {
+								"build": "15.0.3612.1010" // Office 2013 Preview	
+							}
+						},
+						{
+							"from": {
+								"build": "16.0.3629.1006" // Office 2016 Beta
+							}
+						}
+					],
 					"supportedExtensionPoints": [
 						{
 							"code": "addin_command"
@@ -1252,7 +1264,7 @@
 					"supportedRequirementSets": [
 						{
 							"name": "ExcelApi",
-							"apiVersion": "1.1",							
+							"apiVersion": "1.1",
 							"supportedProductVersions": [
 								{
 									"from": {
@@ -1340,7 +1352,7 @@
 								}
 							],
 							"availability": "Beta"
-						},		
+						},
 						{
 							"name": "DialogApi",
 							"supportedProductVersions": [
@@ -1365,59 +1377,59 @@
 						},
 						{
 							"name": "BindingEvents",
-							"apiVersion": "1.1",							
+							"apiVersion": "1.1",
 							"availability": "GA"
-						},						
+						},
 						{
 							"name": "DocumentEvents",
-							"apiVersion": "1.1",							
+							"apiVersion": "1.1",
 							"availability": "GA"
 						},
 						{
 							"name": "MatrixBindings",
-							"apiVersion": "1.1",							
+							"apiVersion": "1.1",
 							"availability": "GA"
 						},
 						{
 							"name": "MatrixCoercion",
-							"apiVersion": "1.1",							
+							"apiVersion": "1.1",
 							"availability": "GA"
 						},
 						{
 							"name": "Settings",
-							"apiVersion": "1.1",							
+							"apiVersion": "1.1",
 							"availability": "GA"
-						},						
+						},
 						{
 							"name": "Selection",
-							"apiVersion": "1.1",							
+							"apiVersion": "1.1",
 							"availability": "GA"
 						},
 						{
 							"name": "TableBindings",
-							"apiVersion": "1.1",							
+							"apiVersion": "1.1",
 							"availability": "GA"
 						},
 						{
 							"name": "TableCoercion",
-							"apiVersion": "1.1",							
+							"apiVersion": "1.1",
 							"availability": "GA"
 						},
 						{
 							"name": "TextBindings",
-							"apiVersion": "1.1",							
+							"apiVersion": "1.1",
 							"availability": "GA"
 						},
 						{
 							"name": "TextCoercion",
-							"apiVersion": "1.1",							
+							"apiVersion": "1.1",
 							"availability": "GA"
 						},
 						{
 							"name": "AddinCommands",
-							"apiVersion": "1.1",							
+							"apiVersion": "1.1",
 							"availability": "GA"
-						},						
+						},
 						{
 							"name": "ImageCoercion",
 							"apiVersion": "1.1",
@@ -1532,7 +1544,7 @@
 							"name": "Settings.set",
 							"apiVersion": "1.1",
 							"availability": "GA"
-						},											
+						},
 						{
 							"name": "TableBinding.addColumnsAsync",
 							"apiVersion": "1.1",
@@ -1584,7 +1596,7 @@
 							"availability": "GA"
 						}
 					]
-				},	
+				},
 				{
 					"code": "WAC",
 					"title": "Excel Online",
@@ -1600,7 +1612,7 @@
 					"supportedRequirementSets": [
 						{
 							"name": "ExcelApi",
-							"apiVersion": "1.1",							
+							"apiVersion": "1.1",
 							"availability": "GA"
 						},
 						{
@@ -1612,7 +1624,7 @@
 							"name": "ExcelApi",
 							"apiVersion": "1.3",
 							"availability": "GA"
-						},						
+						},
 						{
 							"name": "ExcelApi",
 							"apiVersion": "1.4",
@@ -1622,7 +1634,7 @@
 							"name": "ExcelApi",
 							"apiVersion": "1.5",
 							"availability": "GA"
-						},												
+						},
 						{
 							"name": "ExcelApi",
 							"apiVersion": "1.6",
@@ -1632,70 +1644,70 @@
 							"name": "ExcelApi",
 							"apiVersion": "1.7",
 							"availability": "beta"
-						},								
+						},
 						{
 							"name": "BindingEvents",
-							"apiVersion": "1.1",							
+							"apiVersion": "1.1",
 							"availability": "GA"
 						},
 						{
 							"name": "DialogApi",
-							"apiVersion": "1.1",							
+							"apiVersion": "1.1",
 							"availability": "GA"
 						},
 						{
 							"name": "DocumentEvents",
-							"apiVersion": "1.1",							
+							"apiVersion": "1.1",
 							"availability": "GA"
 						},
 						{
 							"name": "AddinCommands",
-							"apiVersion": "1.1",							
+							"apiVersion": "1.1",
 							"availability": "GA"
 						},
 						{
 							"name": "MatrixBindings",
-							"apiVersion": "1.1",							
+							"apiVersion": "1.1",
 							"availability": "GA"
 						},
 						{
 							"name": "MatrixCoercion",
-							"apiVersion": "1.1",							
+							"apiVersion": "1.1",
 							"availability": "GA"
 						},
 						{
 							"name": "Selection",
-							"apiVersion": "1.1",							
+							"apiVersion": "1.1",
 							"availability": "GA"
 						},
 						{
 							"name": "TableBindings",
-							"apiVersion": "1.1",							
+							"apiVersion": "1.1",
 							"availability": "GA"
 						},
 						{
 							"name": "TableCoercion",
-							"apiVersion": "1.1",							
+							"apiVersion": "1.1",
 							"availability": "GA"
 						},
 						{
 							"name": "TextBindings",
-							"apiVersion": "1.1",							
+							"apiVersion": "1.1",
 							"availability": "GA"
 						},
 						{
 							"name": "Settings",
-							"apiVersion": "1.1",							
+							"apiVersion": "1.1",
 							"availability": "GA"
 						},
 						{
 							"name": "TextCoercion",
-							"apiVersion": "1.1",							
+							"apiVersion": "1.1",
 							"availability": "GA"
 						},
 						{
 							"name": "CompressedFile",
-							"apiVersion": "1.1",							
+							"apiVersion": "1.1",
 							"availability": "GA"
 						},
 						{
@@ -1705,7 +1717,7 @@
 						},
 						{
 							"name": "File",
-							"apiVersion": "1.1",							
+							"apiVersion": "1.1",
 							"availability": "GA"
 						}
 					],
@@ -1749,7 +1761,7 @@
 							"name": "Bindings.releaseByIdAsync",
 							"apiVersion": "1.1",
 							"availability": "GA"
-						},												
+						},
 						{
 							"name": "Document.addHandlerAsync",
 							"apiVersion": "1.1",
@@ -1774,12 +1786,12 @@
 							"name": "File.getSliceAsync",
 							"apiVersion": "1.1",
 							"availability": "GA"
-						},												
+						},
 						{
 							"name": "File.closeAsync",
 							"apiVersion": "1.1",
 							"availability": "GA"
-						},												
+						},
 						{
 							"name": "Document.goToByIdAsync",
 							"apiVersion": "1.1",
@@ -1829,17 +1841,17 @@
 							"name": "Settings.refreshAsync",
 							"apiVersion": "1.1",
 							"availability": "GA"
-						},						
+						},
 						{
 							"name": "Settings.addHandlerAsync",
 							"apiVersion": "1.1",
 							"availability": "GA"
-						},						
+						},
 						{
 							"name": "Settings.removeHandlerAsync",
 							"apiVersion": "1.1",
 							"availability": "GA"
-						},												
+						},
 						{
 							"name": "TableBinding.addColumnsAsync",
 							"apiVersion": "1.1",
@@ -1889,7 +1901,7 @@
 							"name": "TextBinding.setDataAsync",
 							"apiVersion": "1.1",
 							"availability": "GA"
-						}																	
+						}
 					]
 				}
 			]
@@ -1910,7 +1922,6 @@
 						}
 					],
 					"supportedAppTypes": [
-						"ContentApp",
 						"TaskPaneApp"
 					],
 					"supportedExtensionPoints": [
@@ -2118,7 +2129,7 @@
 							"name": "Selection",
 							"apiVersion": "1.1",
 							"supportedProductVersions": [
-								{ 
+								{
 									"from": {
 										"build": "1.18",
 										"version": null
@@ -2217,7 +2228,7 @@
 								}
 							],
 							"availability": "GA"
-						}						
+						}
 					],
 					"supportedMethods": [
 						{
@@ -2845,7 +2856,6 @@
 						}
 					],
 					"supportedAppTypes": [
-						"ContentApp",
 						"TaskPaneApp"
 					],
 					"supportedExtensionPoints": [
@@ -3152,7 +3162,7 @@
 								}
 							],
 							"availability": "GA"
-						}						
+						}
 					],
 					"supportedMethods": [
 						{
@@ -3772,7 +3782,6 @@
 					"code": "WAC",
 					"title": "Word Online",
 					"supportedAppTypes": [
-						"ContentApp",
 						"TaskPaneApp"
 					],
 					"supportedExtensionPoints": [
@@ -3820,7 +3829,7 @@
 							"name": "CustomXmlParts",
 							"apiVersion": "1.2",
 							"availability": "GA"
-						},						
+						},
 						{
 							"name": "DocumentEvents",
 							"apiVersion": "1.1",
@@ -4143,8 +4152,19 @@
 				{
 					"code": "Win32",
 					"title": "Word for Windows",
+					"supportedProductVersions": [
+						{
+							"from": {
+								"build": "15.0.3612.1010" // Office 2013 Preview	
+							}
+						},
+						{
+							"from": {
+								"build": "16.0.3629.1006" // Office 2016 Beta
+							}
+						}
+					],
 					"supportedAppTypes": [
-						"ContentApp",
 						"TaskPaneApp"
 					],
 					"supportedExtensionPoints": [
@@ -4191,7 +4211,7 @@
 								}
 							],
 							"availability": "GA"
-						},																						
+						},
 						{
 							"name": "DialogApi",
 							"apiVersion": "1.1",
@@ -4309,7 +4329,7 @@
 							"name": "AddinCommands",
 							"apiVersion": "1.1",
 							"availability": "GA"
-						}						
+						}
 					],
 					"supportedMethods": [
 						{
@@ -4617,7 +4637,7 @@
 							"name": "AddinCommands",
 							"apiVersion": "1.1",
 							"availability": "GA"
-						},						
+						},
 						{
 							"name": "DialogApi",
 							"apiVersion": "1.1",
@@ -4892,7 +4912,7 @@
 							"name": "AddinCommands",
 							"apiVersion": "1.1",
 							"availability": "GA"
-						},						
+						},
 						{
 							"name": "CompressedFile",
 							"apiVersion": "1.1",
@@ -5032,6 +5052,18 @@
 							"code": "addin_command"
 						}
 					],
+					"supportedProductVersions": [
+						{
+							"from": {
+								"build": "15.0.3612.1010" // Office 2013 Preview	
+							}
+						},
+						{
+							"from": {
+								"build": "16.0.3629.1006" // Office 2016 Beta
+							}
+						}
+					],
 					"supportedRequirementSets": [
 						{
 							"name": "ActiveView",
@@ -5082,7 +5114,7 @@
 							"name": "AddinCommands",
 							"apiVersion": "1.1",
 							"availability": "GA"
-						},						
+						},
 						{
 							"name": "DialogApi",
 							"apiVersion": "1.1",
@@ -5184,7 +5216,7 @@
 		},
 		{
 			"code": "OneNote",
-			"host": "OneNote",
+			"host": "Notebook",
 			"platforms": [
 				{
 					"code": "WAC",
@@ -5233,14 +5265,12 @@
 							"name": "DialogApi",
 							"apiVersion": "1.1",
 							"availability": "GA"
-						}												
+						}
 					],
-					"supportedMethods": [
-						
-					]
+					"supportedMethods": []
 				}
 			]
-		},		
+		},
 		{
 			"code": "Access",
 			"host": "Database",
@@ -5282,7 +5312,7 @@
 							"name": "DialogApi",
 							"apiVersion": "1.1",
 							"availability": "GA"
-						}						
+						}
 					],
 					"supportedMethods": [
 						{
@@ -5294,7 +5324,7 @@
 							"name": "Bindings.addFromNamedItemAsync",
 							"apiVersion": "1.1",
 							"availability": "GA"
-						},						
+						},
 						{
 							"name": "Bindings.addFromPromptAsync",
 							"apiVersion": "1.1",
@@ -5415,7 +5445,7 @@
 							"name": "DialogApi",
 							"apiVersion": "1.1",
 							"availability": "GA"
-						}						
+						}
 					],
 					"supportedMethods": [
 						{
@@ -5524,30 +5554,48 @@
 				{
 					"code": "Win32",
 					"title": "Outlook for Windows",
+					"supportedProductVersions": [
+						{
+							"from": {
+								"build": "15.0.847.0"
+							}
+						},
+						{
+							"from": {
+								"build": "16.0.3629.1006" // Office 2016 Beta
+							}
+						}
+					],
 					"supportedAppTypes": [
 						"MailApp"
 					],
-					"supportedExtensionPoints": [{
-						"code": "MessageRead",
-						"firstBuild": null,
-						"firstVersion": null
-					}, {
-						"code": "ComposeCommandSurface",
-						"firstBuild": null,
-						"firstVersion": null
-					}, {
-						"code": "Modules",
-						"firstBuild": null,
-						"firstVersion": null
-					}, {
-						"code": "AppointmentOrganizer",
-						"firstBuild": null,
-						"firstVersion": null
-					}, {
-						"code": "AttendeeCommandSurface",
-						"firstBuild": null,
-						"firstVersion": null
-					}],
+					"supportedExtensionPoints": [
+						{
+							"code": "MessageRead",
+							"firstBuild": null,
+							"firstVersion": null
+						},
+						{
+							"code": "ComposeCommandSurface",
+							"firstBuild": null,
+							"firstVersion": null
+						},
+						{
+							"code": "Modules",
+							"firstBuild": null,
+							"firstVersion": null
+						},
+						{
+							"code": "AppointmentOrganizer",
+							"firstBuild": null,
+							"firstVersion": null
+						},
+						{
+							"code": "AttendeeCommandSurface",
+							"firstBuild": null,
+							"firstVersion": null
+						}
+					],
 					"supportedRequirementSets": [
 						{
 							"name": "Mailbox",
@@ -5610,27 +5658,33 @@
 					"supportedAppTypes": [
 						"MailApp"
 					],
-					"supportedExtensionPoints": [{
-						"code": "MessageRead",
-						"firstBuild": null,
-						"firstVersion": null
-					}, {
-						"code": "ComposeCommandSurface",
-						"firstBuild": null,
-						"firstVersion": null
-					}, {
-						"code": "Modules",
-						"firstBuild": null,
-						"firstVersion": null
-					}, {
-						"code": "AppointmentOrganizer",
-						"firstBuild": null,
-						"firstVersion": null
-					}, {
-						"code": "AttendeeCommandSurface",
-						"firstBuild": null,
-						"firstVersion": null
-					}],
+					"supportedExtensionPoints": [
+						{
+							"code": "MessageRead",
+							"firstBuild": null,
+							"firstVersion": null
+						},
+						{
+							"code": "ComposeCommandSurface",
+							"firstBuild": null,
+							"firstVersion": null
+						},
+						{
+							"code": "Modules",
+							"firstBuild": null,
+							"firstVersion": null
+						},
+						{
+							"code": "AppointmentOrganizer",
+							"firstBuild": null,
+							"firstVersion": null
+						},
+						{
+							"code": "AttendeeCommandSurface",
+							"firstBuild": null,
+							"firstVersion": null
+						}
+					],
 					"supportedRequirementSets": [
 						{
 							"name": "Mailbox",
@@ -5661,27 +5715,33 @@
 					"supportedAppTypes": [
 						"MailApp"
 					],
-					"supportedExtensionPoints": [{
-						"code": "MessageRead",
-						"firstBuild": null,
-						"firstVersion": null
-					}, {
-						"code": "ComposeCommandSurface",
-						"firstBuild": null,
-						"firstVersion": null
-					}, {
-						"code": "Modules",
-						"firstBuild": null,
-						"firstVersion": null
-					}, {
-						"code": "AppointmentOrganizer",
-						"firstBuild": null,
-						"firstVersion": null
-					}, {
-						"code": "AttendeeCommandSurface",
-						"firstBuild": null,
-						"firstVersion": null
-					}],
+					"supportedExtensionPoints": [
+						{
+							"code": "MessageRead",
+							"firstBuild": null,
+							"firstVersion": null
+						},
+						{
+							"code": "ComposeCommandSurface",
+							"firstBuild": null,
+							"firstVersion": null
+						},
+						{
+							"code": "Modules",
+							"firstBuild": null,
+							"firstVersion": null
+						},
+						{
+							"code": "AppointmentOrganizer",
+							"firstBuild": null,
+							"firstVersion": null
+						},
+						{
+							"code": "AttendeeCommandSurface",
+							"firstBuild": null,
+							"firstVersion": null
+						}
+					],
 					"supportedRequirementSets": [
 						{
 							"name": "Mailbox",
@@ -5712,27 +5772,33 @@
 					"supportedAppTypes": [
 						"MailApp"
 					],
-					"supportedExtensionPoints": [{
-						"code": "MessageRead",
-						"firstBuild": null,
-						"firstVersion": null
-					}, {
-						"code": "ComposeCommandSurface",
-						"firstBuild": null,
-						"firstVersion": null
-					}, {
-						"code": "Modules",
-						"firstBuild": null,
-						"firstVersion": null
-					}, {
-						"code": "AppointmentOrganizer",
-						"firstBuild": null,
-						"firstVersion": null
-					}, {
-						"code": "AttendeeCommandSurface",
-						"firstBuild": null,
-						"firstVersion": null
-					}],
+					"supportedExtensionPoints": [
+						{
+							"code": "MessageRead",
+							"firstBuild": null,
+							"firstVersion": null
+						},
+						{
+							"code": "ComposeCommandSurface",
+							"firstBuild": null,
+							"firstVersion": null
+						},
+						{
+							"code": "Modules",
+							"firstBuild": null,
+							"firstVersion": null
+						},
+						{
+							"code": "AppointmentOrganizer",
+							"firstBuild": null,
+							"firstVersion": null
+						},
+						{
+							"code": "AttendeeCommandSurface",
+							"firstBuild": null,
+							"firstVersion": null
+						}
+					],
 					"supportedRequirementSets": [
 						{
 							"name": "Mailbox",
@@ -5752,6 +5818,53 @@
 						{
 							"name": "Mailbox",
 							"apiVersion": "1.4",
+							"availability": "GA"
+						}
+					],
+					"supportedMethods": []
+				}
+			]
+		},
+		{
+			"code": "Teams",
+			"platforms": [
+				{
+					"code": "Any",
+					"title": "Teams",
+					"supportedAppTypes": [
+						"ContentApp"
+					],
+					"supportedExtensionPoints": [],
+					"supportedRequirementSets": [
+						{
+							"name": "TeamsAPI",
+							"apiVersion": "1.0",
+							"availability": "GA"
+						}
+					],
+					"supportedMethods": []
+				}
+			]
+		},
+		{
+			"code": "PowerBI",
+			"platforms": [
+				{
+					"code": "Any",
+					"title": "Power BI",
+					"supportedAppTypes": [
+						"ContentApp"
+					],
+					"supportedExtensionPoints": [],
+					"supportedRequirementSets": [
+						{
+							"name": "DataAnalytics.PowerBI",
+							"apiVersion": "1.1",
+							"availability": "GA"
+						},
+						{
+							"name": "BuiltWithR.PowerBI",
+							"apiVersion": "1.1",
 							"availability": "GA"
 						}
 					],

--- a/mapping/schema_requirements.json
+++ b/mapping/schema_requirements.json
@@ -38,7 +38,7 @@
                 }
             }
         },
-        "buildVersionRange": {
+        "buildVersionInterval": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -54,10 +54,7 @@
                 "excludeTo": {
                     "type": "boolean"
                 }
-            },
-            "required": [
-                "begin"
-            ]
+            }
         },
         "extensionPoint": {
             "type": "object",
@@ -68,7 +65,7 @@
                 "supportedProductVersions": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/buildVersionRange"
+                        "$ref": "#/definitions/buildVersionInterval"
                     }
                 }
             },
@@ -100,7 +97,7 @@
                 "supportedProductVersions": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/buildVersionRange"
+                        "$ref": "#/definitions/buildVersionInterval"
                     }
                 },
                 "apiVersion": {
@@ -149,7 +146,7 @@
                 "supportedProductVersions": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/buildVersionRange"
+                        "$ref": "#/definitions/buildVersionInterval"
                     }
                 },
                 "title": {
@@ -198,7 +195,6 @@
             },
             "required": [
                 "code",
-                "host",
                 "platforms"
             ]
         },
@@ -228,7 +224,7 @@
                 "supportedProductVersions": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/buildVersionRange"
+                        "$ref": "#/definitions/buildVersionInterval"
                     }
                 },
                 "apiVersion": {


### PR DESCRIPTION
- Added default builds for Win32 platform (set to earliest build numbers found on Internet for Office 2013 and Office 2016) - required for implementation on OMEX side
- Added missing Teams and Power BI products with status quo data
- Fixed formatting
- Minor fixes in type naming and required fields in the schema. made sure that data conforms to schema.