### PR TITLE
Add 16.0 to be minimum build for AddinCommands requirement set.

### DIFF
--- a/mapping/requirements_officejs.json
+++ b/mapping/requirements_officejs.json
@@ -1661,6 +1661,13 @@
 						{
 							"name": "AddinCommands",
 							"apiVersion": "1.1",
+							"supportedProductVersions": [
+								{
+									"from": {
+										"build": "16.0"
+									}
+								}
+							],
 							"availability": "GA"
 						},
 						{
@@ -4626,6 +4633,13 @@
 						{
 							"name": "AddinCommands",
 							"apiVersion": "1.1",
+							"supportedProductVersions": [
+								{
+									"from": {
+										"build": "16.0"
+									}
+								}
+							],
 							"availability": "GA"
 						}
 					],
@@ -5448,6 +5462,13 @@
 						{
 							"name": "AddinCommands",
 							"apiVersion": "1.1",
+							"supportedProductVersions": [
+								{
+									"from": {
+										"build": "16.0"
+									}
+								}
+							],
 							"availability": "GA"
 						},
 						{


### PR DESCRIPTION
Currently, if add-in has AddinCommands requirement set it is incorrectly being tagged by Office 2013 clients which do not support it and will never do. This PR is to scope AddinCommands to Office 2016 only.