### PR TITLE
Add apiVersion to DialogApi in Excel for Windows.

### DIFF
--- a/mapping/requirements_officejs.json
+++ b/mapping/requirements_officejs.json
@@ -1362,6 +1362,7 @@
 						},
 						{
 							"name": "DialogApi",
+							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 									"from": {
 										"build": "15.0.4855.1000",


### PR DESCRIPTION
Lack of version causes add-ins requesting it being wrongly considered incompatible with Excel for Windows.