### PR TITLE
Change ExcelApi build versions for Mac

### DIFF
--- a/mapping/requirements_officejs.json
+++ b/mapping/requirements_officejs.json
@@ -711,7 +711,7 @@
 							"apiVersion": "1.7",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "16.9",
+									"build": "16.0.125.1000",
 									"version": null
 								}
 							}],

--- a/mapping/requirements_officejs.json
+++ b/mapping/requirements_officejs.json
@@ -733,7 +733,7 @@
 							"apiVersion": "1.9",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "16.24",
+									"build": "16.0.403.1000",
 									"version": null
 								}
 							}],

--- a/mapping/requirements_officejs.json
+++ b/mapping/requirements_officejs.json
@@ -931,7 +931,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "16.23",
+									"build": "16.0.403.1000",
 									"version": null
 								}
 							}],


### PR DESCRIPTION
Change Excel API 1.9 version for Mac in order for custom functions to work