### PR TITLE
Change bundle-num to build-num for MacOs

### DIFF
--- a/mapping/requirements_officejs.json
+++ b/mapping/requirements_officejs.json
@@ -645,7 +645,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.20",
+									"build": "15.20.203.0",
 									"version": null
 								}
 							}],
@@ -656,7 +656,7 @@
 							"apiVersion": "1.2",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.22",
+									"build": "15.22.501.0",
 									"version": null
 								}
 							}],
@@ -667,7 +667,7 @@
 							"apiVersion": "1.3",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.27",
+									"build": "15.27.1003.0",
 									"version": null
 								}
 							}],
@@ -678,7 +678,7 @@
 							"apiVersion": "1.4",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.36",
+									"build": "15.36.524.0",
 									"version": null
 								}
 							}],
@@ -689,7 +689,7 @@
 							"apiVersion": "1.5",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.36",
+									"build": "15.36.524.0",
 									"version": null
 								}
 							}],
@@ -700,7 +700,7 @@
 							"apiVersion": "1.6",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.36",
+									"build": "15.36.524.0",
 									"version": null
 								}
 							}],
@@ -744,7 +744,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.36",
+									"build": "15.36.524.0",
 									"version": null
 								}
 							}],
@@ -766,7 +766,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.20",
+									"build": "15.20.203.0",
 									"version": null
 								}
 							}],
@@ -777,7 +777,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.20",
+									"build": "15.20.203.0",
 									"version": null
 								}
 							}],
@@ -788,7 +788,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.20",
+									"build": "15.20.203.0",
 									"version": null
 								}
 							}],
@@ -799,7 +799,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.39",
+									"build": "15.38.902.0",
 									"version": null
 								}
 							}],
@@ -909,7 +909,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.32",
+									"build": "15.32.201.0",
 									"version": null
 								}
 							}],
@@ -1020,7 +1020,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.36",
+									"build": "15.36.524.0",
 									"version": null
 								}
 							}],
@@ -1031,7 +1031,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.36",
+									"build": "15.36.524.0",
 									"version": null
 								}
 							}],
@@ -2828,7 +2828,7 @@
 					"title": "Word for Mac",
 					"supportedProductVersions": [{
 						"from": {
-							"build": "15.19",
+							"build": "15.19.212.1",
 							"version": null
 						}
 					}],
@@ -2843,7 +2843,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19",
+									"build": "15.19.212.1",
 									"version": null
 								}
 							}],
@@ -2854,7 +2854,7 @@
 							"apiVersion": "1.2",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19",
+									"build": "15.19.212.1",
 									"version": null
 								}
 							}],
@@ -2865,7 +2865,7 @@
 							"apiVersion": "1.3",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.32",
+									"build": "15.32.201.0",
 									"version": null
 								}
 							}],
@@ -2876,7 +2876,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.20",
+									"build": "15.20.203.0",
 									"version": null
 								}
 							}],
@@ -2887,7 +2887,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.39",
+									"build": "15.38.902.0",
 									"version": null
 								}
 							}],
@@ -2898,7 +2898,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19",
+									"build": "15.19.212.1",
 									"version": null
 								}
 							}],
@@ -2909,7 +2909,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19",
+									"build": "15.19.212.1",
 									"version": null
 								}
 							}],
@@ -2920,7 +2920,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19",
+									"build": "15.19.212.1",
 									"version": null
 								}
 							}],
@@ -2931,7 +2931,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19",
+									"build": "15.19.212.1",
 									"version": null
 								}
 							}],
@@ -2942,7 +2942,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19",
+									"build": "15.19.212.1",
 									"version": null
 								}
 							}],
@@ -2953,7 +2953,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19",
+									"build": "15.19.212.1",
 									"version": null
 								}
 							}],
@@ -2964,7 +2964,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19",
+									"build": "15.19.212.1",
 									"version": null
 								}
 							}],
@@ -2975,7 +2975,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19",
+									"build": "15.19.212.1",
 									"version": null
 								}
 							}],
@@ -2986,7 +2986,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19",
+									"build": "15.19.212.1",
 									"version": null
 								}
 							}],
@@ -2997,7 +2997,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19",
+									"build": "15.19.212.1",
 									"version": null
 								}
 							}],
@@ -3008,7 +3008,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19",
+									"build": "15.19.212.1",
 									"version": null
 								}
 							}],
@@ -3019,7 +3019,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19",
+									"build": "15.19.212.1",
 									"version": null
 								}
 							}],
@@ -3030,7 +3030,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19",
+									"build": "15.19.212.1",
 									"version": null
 								}
 							}],
@@ -3041,7 +3041,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19",
+									"build": "15.19.212.1",
 									"version": null
 								}
 							}],
@@ -3052,7 +3052,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19",
+									"build": "15.19.212.1",
 									"version": null
 								}
 							}],
@@ -3063,7 +3063,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19",
+									"build": "15.19.212.1",
 									"version": null
 								}
 							}],
@@ -3074,7 +3074,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19",
+									"build": "15.19.212.1",
 									"version": null
 								}
 							}],
@@ -3085,7 +3085,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19",
+									"build": "15.19.212.1",
 									"version": null
 								}
 							}],
@@ -3096,7 +3096,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.32",
+									"build": "15.32.201.0",
 									"version": null
 								}
 							}],
@@ -3108,7 +3108,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19",
+									"build": "15.19.212.1",
 									"version": null
 								}
 							}],
@@ -3119,7 +3119,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19",
+									"build": "15.19.212.1",
 									"version": null
 								}
 							}],
@@ -3130,7 +3130,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19",
+									"build": "15.19.212.1",
 									"version": null
 								}
 							}],
@@ -3141,7 +3141,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19",
+									"build": "15.19.212.1",
 									"version": null
 								}
 							}],
@@ -3152,7 +3152,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19",
+									"build": "15.19.212.1",
 									"version": null
 								}
 							}],
@@ -3163,7 +3163,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19",
+									"build": "15.19.212.1",
 									"version": null
 								}
 							}],
@@ -3174,7 +3174,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19",
+									"build": "15.19.212.1",
 									"version": null
 								}
 							}],
@@ -3185,7 +3185,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19",
+									"build": "15.19.212.1",
 									"version": null
 								}
 							}],
@@ -3196,7 +3196,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19",
+									"build": "15.19.212.1",
 									"version": null
 								}
 							}],
@@ -3207,7 +3207,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19",
+									"build": "15.19.212.1",
 									"version": null
 								}
 							}],
@@ -3218,7 +3218,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19",
+									"build": "15.19.212.1",
 									"version": null
 								}
 							}],
@@ -3229,7 +3229,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19",
+									"build": "15.19.212.1",
 									"version": null
 								}
 							}],
@@ -3240,7 +3240,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19",
+									"build": "15.19.212.1",
 									"version": null
 								}
 							}],
@@ -3251,7 +3251,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19",
+									"build": "15.19.212.1",
 									"version": null
 								}
 							}],
@@ -3262,7 +3262,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19",
+									"build": "15.19.212.1",
 									"version": null
 								}
 							}],
@@ -3273,7 +3273,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19",
+									"build": "15.19.212.1",
 									"version": null
 								}
 							}],
@@ -3284,7 +3284,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19",
+									"build": "15.19.212.1",
 									"version": null
 								}
 							}],
@@ -3295,7 +3295,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19",
+									"build": "15.19.212.1",
 									"version": null
 								}
 							}],
@@ -3306,7 +3306,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19",
+									"build": "15.19.212.1",
 									"version": null
 								}
 							}],
@@ -3317,7 +3317,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19",
+									"build": "15.19.212.1",
 									"version": null
 								}
 							}],
@@ -3328,7 +3328,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19",
+									"build": "15.19.212.1",
 									"version": null
 								}
 							}],
@@ -3339,7 +3339,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19",
+									"build": "15.19.212.1",
 									"version": null
 								}
 							}],
@@ -3350,7 +3350,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19",
+									"build": "15.19.212.1",
 									"version": null
 								}
 							}],
@@ -3361,7 +3361,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19",
+									"build": "15.19.212.1",
 									"version": null
 								}
 							}],
@@ -3372,7 +3372,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19",
+									"build": "15.19.212.1",
 									"version": null
 								}
 							}],
@@ -3383,7 +3383,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19",
+									"build": "15.19.212.1",
 									"version": null
 								}
 							}],
@@ -3394,7 +3394,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19",
+									"build": "15.19.212.1",
 									"version": null
 								}
 							}],
@@ -3405,7 +3405,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19",
+									"build": "15.19.212.1",
 									"version": null
 								}
 							}],
@@ -3416,7 +3416,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19",
+									"build": "15.19.212.1",
 									"version": null
 								}
 							}],
@@ -3427,7 +3427,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19",
+									"build": "15.19.212.1",
 									"version": null
 								}
 							}],
@@ -3438,7 +3438,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19",
+									"build": "15.19.212.1",
 									"version": null
 								}
 							}],
@@ -3449,7 +3449,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19",
+									"build": "15.19.212.1",
 									"version": null
 								}
 							}],
@@ -3460,7 +3460,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19",
+									"build": "15.19.212.1",
 									"version": null
 								}
 							}],
@@ -3471,7 +3471,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19",
+									"build": "15.19.212.1",
 									"version": null
 								}
 							}],
@@ -3482,7 +3482,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19",
+									"build": "15.19.212.1",
 									"version": null
 								}
 							}],
@@ -3493,7 +3493,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19",
+									"build": "15.19.212.1",
 									"version": null
 								}
 							}],
@@ -3504,7 +3504,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19",
+									"build": "15.19.212.1",
 									"version": null
 								}
 							}],
@@ -3515,7 +3515,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19",
+									"build": "15.19.212.1",
 									"version": null
 								}
 							}],
@@ -3526,7 +3526,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19",
+									"build": "15.19.212.1",
 									"version": null
 								}
 							}],
@@ -3537,7 +3537,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19",
+									"build": "15.19.212.1",
 									"version": null
 								}
 							}],
@@ -3548,7 +3548,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19",
+									"build": "15.19.212.1",
 									"version": null
 								}
 							}],
@@ -3559,7 +3559,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19",
+									"build": "15.19.212.1",
 									"version": null
 								}
 							}],
@@ -3570,7 +3570,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19",
+									"build": "15.19.212.1",
 									"version": null
 								}
 							}],
@@ -3581,7 +3581,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19",
+									"build": "15.19.212.1",
 									"version": null
 								}
 							}],
@@ -3592,7 +3592,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19",
+									"build": "15.19.212.1",
 									"version": null
 								}
 							}],
@@ -3603,7 +3603,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19",
+									"build": "15.19.212.1",
 									"version": null
 								}
 							}],
@@ -3614,7 +3614,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19",
+									"build": "15.19.212.1",
 									"version": null
 								}
 							}],
@@ -4659,7 +4659,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.39",
+									"build": "15.38.902.0",
 									"version": null
 								}
 							}],

--- a/mapping/requirements_officejs.json
+++ b/mapping/requirements_officejs.json
@@ -799,7 +799,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.38.902.0",
+									"build": "15.38.801.0",
 									"version": null
 								}
 							}],

--- a/mapping/requirements_officejs.json
+++ b/mapping/requirements_officejs.json
@@ -799,7 +799,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.38.801.0",
+									"build": "15.39.1004.0",
 									"version": null
 								}
 							}],
@@ -4659,7 +4659,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.38.902.0",
+									"build": "15.39.1004.0",
 									"version": null
 								}
 							}],

--- a/mapping/requirements_officejs.json
+++ b/mapping/requirements_officejs.json
@@ -667,7 +667,7 @@
 							"apiVersion": "1.3",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.27.1003.0",
+									"build": "15.0.1003.0",
 									"version": null
 								}
 							}],
@@ -909,7 +909,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.32.201.0",
+									"build": "15.0.201.0",
 									"version": null
 								}
 							}],
@@ -4659,7 +4659,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.39.1004.0",
+									"build": "15.0.1004.0",
 									"version": null
 								}
 							}],

--- a/mapping/requirements_officejs.json
+++ b/mapping/requirements_officejs.json
@@ -645,7 +645,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.20.203.0",
+									"build": "15.0.203.0",
 									"version": null
 								}
 							}],
@@ -656,7 +656,7 @@
 							"apiVersion": "1.2",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.22.501.0",
+									"build": "15.0.501.0",
 									"version": null
 								}
 							}],
@@ -678,7 +678,7 @@
 							"apiVersion": "1.4",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.36.524.0",
+									"build": "15.0.524.0",
 									"version": null
 								}
 							}],
@@ -689,7 +689,7 @@
 							"apiVersion": "1.5",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.36.524.0",
+									"build": "15.0.524.0",
 									"version": null
 								}
 							}],
@@ -700,7 +700,7 @@
 							"apiVersion": "1.6",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.36.524.0",
+									"build": "15.0.524.0",
 									"version": null
 								}
 							}],
@@ -744,7 +744,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.36.524.0",
+									"build": "15.0.524.0",
 									"version": null
 								}
 							}],
@@ -766,7 +766,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.20.203.0",
+									"build": "15.0.203.0",
 									"version": null
 								}
 							}],
@@ -777,7 +777,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.20.203.0",
+									"build": "15.0.203.0",
 									"version": null
 								}
 							}],
@@ -788,7 +788,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.20.203.0",
+									"build": "15.0.203.0",
 									"version": null
 								}
 							}],
@@ -799,7 +799,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.39.1004.0",
+									"build": "15.0.1004.0",
 									"version": null
 								}
 							}],
@@ -1020,7 +1020,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.36.524.0",
+									"build": "15.0.524.0",
 									"version": null
 								}
 							}],
@@ -1031,7 +1031,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.36.524.0",
+									"build": "15.0.524.0",
 									"version": null
 								}
 							}],
@@ -2828,7 +2828,7 @@
 					"title": "Word for Mac",
 					"supportedProductVersions": [{
 						"from": {
-							"build": "15.19.212.1",
+							"build": "15.0.212.1",
 							"version": null
 						}
 					}],
@@ -2843,7 +2843,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19.212.1",
+									"build": "15.0.212.1",
 									"version": null
 								}
 							}],
@@ -2854,7 +2854,7 @@
 							"apiVersion": "1.2",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19.212.1",
+									"build": "15.0.212.1",
 									"version": null
 								}
 							}],
@@ -2865,7 +2865,7 @@
 							"apiVersion": "1.3",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.32.201.0",
+									"build": "15.0.201.0",
 									"version": null
 								}
 							}],
@@ -2876,7 +2876,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.20.203.0",
+									"build": "15.0.203.0",
 									"version": null
 								}
 							}],
@@ -2887,7 +2887,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.39.1004.0",
+									"build": "15.0.1004.0",
 									"version": null
 								}
 							}],
@@ -2898,7 +2898,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19.212.1",
+									"build": "15.0.212.1",
 									"version": null
 								}
 							}],
@@ -2909,7 +2909,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19.212.1",
+									"build": "15.0.212.1",
 									"version": null
 								}
 							}],
@@ -2920,7 +2920,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19.212.1",
+									"build": "15.0.212.1",
 									"version": null
 								}
 							}],
@@ -2931,7 +2931,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19.212.1",
+									"build": "15.0.212.1",
 									"version": null
 								}
 							}],
@@ -2942,7 +2942,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19.212.1",
+									"build": "15.0.212.1",
 									"version": null
 								}
 							}],
@@ -2953,7 +2953,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19.212.1",
+									"build": "15.0.212.1",
 									"version": null
 								}
 							}],
@@ -2964,7 +2964,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19.212.1",
+									"build": "15.0.212.1",
 									"version": null
 								}
 							}],
@@ -2975,7 +2975,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19.212.1",
+									"build": "15.0.212.1",
 									"version": null
 								}
 							}],
@@ -2986,7 +2986,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19.212.1",
+									"build": "15.0.212.1",
 									"version": null
 								}
 							}],
@@ -2997,7 +2997,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19.212.1",
+									"build": "15.0.212.1",
 									"version": null
 								}
 							}],
@@ -3008,7 +3008,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19.212.1",
+									"build": "15.0.212.1",
 									"version": null
 								}
 							}],
@@ -3019,7 +3019,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19.212.1",
+									"build": "15.0.212.1",
 									"version": null
 								}
 							}],
@@ -3030,7 +3030,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19.212.1",
+									"build": "15.0.212.1",
 									"version": null
 								}
 							}],
@@ -3041,7 +3041,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19.212.1",
+									"build": "15.0.212.1",
 									"version": null
 								}
 							}],
@@ -3052,7 +3052,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19.212.1",
+									"build": "15.0.212.1",
 									"version": null
 								}
 							}],
@@ -3063,7 +3063,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19.212.1",
+									"build": "15.0.212.1",
 									"version": null
 								}
 							}],
@@ -3074,7 +3074,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19.212.1",
+									"build": "15.0.212.1",
 									"version": null
 								}
 							}],
@@ -3085,7 +3085,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19.212.1",
+									"build": "15.0.212.1",
 									"version": null
 								}
 							}],
@@ -3096,7 +3096,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.32.201.0",
+									"build": "15.0.201.0",
 									"version": null
 								}
 							}],
@@ -3108,7 +3108,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19.212.1",
+									"build": "15.0.212.1",
 									"version": null
 								}
 							}],
@@ -3119,7 +3119,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19.212.1",
+									"build": "15.0.212.1",
 									"version": null
 								}
 							}],
@@ -3130,7 +3130,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19.212.1",
+									"build": "15.0.212.1",
 									"version": null
 								}
 							}],
@@ -3141,7 +3141,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19.212.1",
+									"build": "15.0.212.1",
 									"version": null
 								}
 							}],
@@ -3152,7 +3152,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19.212.1",
+									"build": "15.0.212.1",
 									"version": null
 								}
 							}],
@@ -3163,7 +3163,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19.212.1",
+									"build": "15.0.212.1",
 									"version": null
 								}
 							}],
@@ -3174,7 +3174,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19.212.1",
+									"build": "15.0.212.1",
 									"version": null
 								}
 							}],
@@ -3185,7 +3185,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19.212.1",
+									"build": "15.0.212.1",
 									"version": null
 								}
 							}],
@@ -3196,7 +3196,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19.212.1",
+									"build": "15.0.212.1",
 									"version": null
 								}
 							}],
@@ -3207,7 +3207,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19.212.1",
+									"build": "15.0.212.1",
 									"version": null
 								}
 							}],
@@ -3218,7 +3218,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19.212.1",
+									"build": "15.0.212.1",
 									"version": null
 								}
 							}],
@@ -3229,7 +3229,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19.212.1",
+									"build": "15.0.212.1",
 									"version": null
 								}
 							}],
@@ -3240,7 +3240,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19.212.1",
+									"build": "15.0.212.1",
 									"version": null
 								}
 							}],
@@ -3251,7 +3251,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19.212.1",
+									"build": "15.0.212.1",
 									"version": null
 								}
 							}],
@@ -3262,7 +3262,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19.212.1",
+									"build": "15.0.212.1",
 									"version": null
 								}
 							}],
@@ -3273,7 +3273,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19.212.1",
+									"build": "15.0.212.1",
 									"version": null
 								}
 							}],
@@ -3284,7 +3284,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19.212.1",
+									"build": "15.0.212.1",
 									"version": null
 								}
 							}],
@@ -3295,7 +3295,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19.212.1",
+									"build": "15.0.212.1",
 									"version": null
 								}
 							}],
@@ -3306,7 +3306,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19.212.1",
+									"build": "15.0.212.1",
 									"version": null
 								}
 							}],
@@ -3317,7 +3317,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19.212.1",
+									"build": "15.0.212.1",
 									"version": null
 								}
 							}],
@@ -3328,7 +3328,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19.212.1",
+									"build": "15.0.212.1",
 									"version": null
 								}
 							}],
@@ -3339,7 +3339,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19.212.1",
+									"build": "15.0.212.1",
 									"version": null
 								}
 							}],
@@ -3350,7 +3350,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19.212.1",
+									"build": "15.0.212.1",
 									"version": null
 								}
 							}],
@@ -3361,7 +3361,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19.212.1",
+									"build": "15.0.212.1",
 									"version": null
 								}
 							}],
@@ -3372,7 +3372,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19.212.1",
+									"build": "15.0.212.1",
 									"version": null
 								}
 							}],
@@ -3383,7 +3383,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19.212.1",
+									"build": "15.0.212.1",
 									"version": null
 								}
 							}],
@@ -3394,7 +3394,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19.212.1",
+									"build": "15.0.212.1",
 									"version": null
 								}
 							}],
@@ -3405,7 +3405,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19.212.1",
+									"build": "15.0.212.1",
 									"version": null
 								}
 							}],
@@ -3416,7 +3416,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19.212.1",
+									"build": "15.0.212.1",
 									"version": null
 								}
 							}],
@@ -3427,7 +3427,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19.212.1",
+									"build": "15.0.212.1",
 									"version": null
 								}
 							}],
@@ -3438,7 +3438,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19.212.1",
+									"build": "15.0.212.1",
 									"version": null
 								}
 							}],
@@ -3449,7 +3449,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19.212.1",
+									"build": "15.0.212.1",
 									"version": null
 								}
 							}],
@@ -3460,7 +3460,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19.212.1",
+									"build": "15.0.212.1",
 									"version": null
 								}
 							}],
@@ -3471,7 +3471,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19.212.1",
+									"build": "15.0.212.1",
 									"version": null
 								}
 							}],
@@ -3482,7 +3482,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19.212.1",
+									"build": "15.0.212.1",
 									"version": null
 								}
 							}],
@@ -3493,7 +3493,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19.212.1",
+									"build": "15.0.212.1",
 									"version": null
 								}
 							}],
@@ -3504,7 +3504,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19.212.1",
+									"build": "15.0.212.1",
 									"version": null
 								}
 							}],
@@ -3515,7 +3515,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19.212.1",
+									"build": "15.0.212.1",
 									"version": null
 								}
 							}],
@@ -3526,7 +3526,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19.212.1",
+									"build": "15.0.212.1",
 									"version": null
 								}
 							}],
@@ -3537,7 +3537,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19.212.1",
+									"build": "15.0.212.1",
 									"version": null
 								}
 							}],
@@ -3548,7 +3548,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19.212.1",
+									"build": "15.0.212.1",
 									"version": null
 								}
 							}],
@@ -3559,7 +3559,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19.212.1",
+									"build": "15.0.212.1",
 									"version": null
 								}
 							}],
@@ -3570,7 +3570,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19.212.1",
+									"build": "15.0.212.1",
 									"version": null
 								}
 							}],
@@ -3581,7 +3581,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19.212.1",
+									"build": "15.0.212.1",
 									"version": null
 								}
 							}],
@@ -3592,7 +3592,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19.212.1",
+									"build": "15.0.212.1",
 									"version": null
 								}
 							}],
@@ -3603,7 +3603,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19.212.1",
+									"build": "15.0.212.1",
 									"version": null
 								}
 							}],
@@ -3614,7 +3614,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.19.212.1",
+									"build": "15.0.212.1",
 									"version": null
 								}
 							}],

--- a/mapping/requirements_officejs.json
+++ b/mapping/requirements_officejs.json
@@ -2887,7 +2887,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.38.902.0",
+									"build": "15.39.1004.0",
 									"version": null
 								}
 							}],


### PR DESCRIPTION
This only includes the MacOS versions which sends us traffic. 15.10-15.13 are not in this range and hence they are unchanged.