### PR TITLE
Fallback Excel API 1.8 on Mac to 1.9

### DIFF
--- a/mapping/requirements_officejs.json
+++ b/mapping/requirements_officejs.json
@@ -733,7 +733,7 @@
 							"apiVersion": "1.8",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "16.17",
+									"build": "16.0.403.1000",
 									"version": null
 								}
 							}],


### PR DESCRIPTION
Fallback Excel API 1.8 on Mac to 1.9 to mitigate the issue that add-in missing from store due to wrong build format