### PR TITLE
Add 1.8 requirement set for Outlook

### DIFF
--- a/mapping/requirements_officejs.json
+++ b/mapping/requirements_officejs.json
@@ -5611,7 +5611,18 @@
 								}
 							}],
 							"availability": "GA"
-						}                        
+						},
+						{
+							"name": "Mailbox",
+							"apiVersion": "1.8",
+							"supportedProductVersions": [{
+								"from": {
+									"build": "15.20.2078.0",
+									"version": null
+								}
+							}],
+							"availability": "GA"
+						}                    
 					],
 					"supportedMethods": []
 				},
@@ -5714,6 +5725,17 @@
 							"supportedProductVersions": [{
 								"from": {
 									"build": "15.20.1063.0",
+									"version": null
+								}
+							}],
+							"availability": "GA"
+						},
+						{
+							"name": "Mailbox",
+							"apiVersion": "1.8",
+							"supportedProductVersions": [{
+								"from": {
+									"build": "15.20.2078.0",
 									"version": null
 								}
 							}],
@@ -5982,6 +6004,17 @@
 							"supportedProductVersions": [{
 								"from": {
 									"build": "15.20.1063.0",
+									"version": null
+								}
+							}],
+							"availability": "GA"
+						},
+						{
+							"name": "Mailbox",
+							"apiVersion": "1.8",
+							"supportedProductVersions": [{
+								"from": {
+									"build": "15.20.2078.0",
 									"version": null
 								}
 							}],


### PR DESCRIPTION
Add the 1.8 API requirement set for Outlook Win32, WAC and macOS.