### PR TITLE
Update the requirement set for Dialog API 1.2 (WIn32, WAC, Mac and iOS)

### DIFF
--- a/mapping/requirements_officejs.json
+++ b/mapping/requirements_officejs.json
@@ -171,6 +171,17 @@
 							"availability": "GA"
 						},
 						{
+							"name": "DialogApi",
+							"apiVersion": "1.2",
+							"supportedProductVersions": [{
+								"from": {
+									"build": "2.37.504.0",
+									"version": null
+								}
+							}],
+							"availability": "GA"
+						},
+						{
 							"name": "DocumentEvents",
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
@@ -822,6 +833,17 @@
 							"supportedProductVersions": [{
 								"from": {
 									"build": "15.0.203.0",
+									"version": null
+								}
+							}],
+							"availability": "GA"
+						},
+						{
+							"name": "DialogApi",
+							"apiVersion": "1.2",
+							"supportedProductVersions": [{
+								"from": {
+									"build": "16.37.20051002",
 									"version": null
 								}
 							}],
@@ -1559,6 +1581,19 @@
 							"availability": "GA"
 						},
 						{
+							"name": "DialogApi",
+							"apiVersion": "1.2",
+							"supportedProductVersions": [
+								{
+									"from": {
+										"build": "16.0.12527.20720",
+										"version": null
+									}
+								}
+							],
+							"availability": "GA"
+						},
+						{
 							"name": "BindingEvents",
 							"apiVersion": "1.1",
 							"availability": "GA"
@@ -1916,6 +1951,11 @@
 							"availability": "GA"
 						},
 						{
+							"name": "DialogApi",
+							"apiVersion": "1.2",
+							"availability": "GA"
+						},
+						{
 							"name": "IdentityAPI",
 							"apiVersion": "1.1",
 							"availability": "GA"
@@ -2225,6 +2265,17 @@
 							"supportedProductVersions": [{
 								"from": {
 									"build": "1.22",
+									"version": null
+								}
+							}],
+							"availability": "GA"
+						},
+						{
+							"name": "DialogApi",
+							"apiVersion": "1.2",
+							"supportedProductVersions": [{
+								"from": {
+									"build": "2.37.504.0",
 									"version": null
 								}
 							}],
@@ -3008,6 +3059,17 @@
 							"availability": "GA"
 						},
 						{
+							"name": "DialogApi",
+							"apiVersion": "1.2",
+							"supportedProductVersions": [{
+								"from": {
+									"build": "16.37.20051002",
+									"version": null
+								}
+							}],
+							"availability": "GA"
+						},
+						{
 							"name": "IdentityAPI",
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
@@ -3783,6 +3845,11 @@
 							"availability": "GA"
 						},
 						{
+							"name": "DialogApi",
+							"apiVersion": "1.2",
+							"availability": "GA"
+						},
+						{
 							"name": "IdentityAPI",
 							"apiVersion": "1.1",
 							"availability": "GA"
@@ -4220,6 +4287,19 @@
 							"availability": "GA"
 						},
 						{
+							"name": "DialogApi",
+							"apiVersion": "1.2",
+							"availability": "GA",
+							"supportedProductVersions": [
+								{
+									"from": {
+										"build": "16.0.12527.20720",
+										"version": null
+									}
+								}
+							]
+						},
+						{
 							"name": "BindingEvents",
 							"apiVersion": "1.1",
 							"availability": "GA"
@@ -4631,7 +4711,18 @@
 								}
 							}],
 							"availability": "GA"
-                        },
+						},
+						{
+							"name": "DialogApi",
+							"apiVersion": "1.2",
+							"supportedProductVersions": [{
+								"from": {
+									"build": "2.37.504.0",
+									"version": null
+								}
+							}],
+							"availability": "GA"
+						},
 						{
 							"name": "PowerPointApi",
 							"apiVersion": "1.1",
@@ -4822,7 +4913,18 @@
 									}
 								}
 							]
-                        },
+						},
+						{
+							"name": "DialogApi",
+							"apiVersion": "1.2",
+							"supportedProductVersions": [{
+								"from": {
+									"build": "16.37.20051002",
+									"version": null
+								}
+							}],
+							"availability": "GA"
+						},
 						{
 							"name": "PowerPointApi",
 							"apiVersion": "1.1",
@@ -4971,12 +5073,17 @@
 							"name": "DialogApi",
 							"apiVersion": "1.1",
 							"availability": "GA"
-                        },
+						},
+						{
+							"name": "DialogApi",
+							"apiVersion": "1.2",
+							"availability": "GA"
+						},
 						{
 							"name": "PowerPointApi",
 							"apiVersion": "1.1",
 							"availability": "GA"
-						}                        
+						}
 					],
 					"supportedMethods": [{
 							"name": "Document.addHandlerAsync",
@@ -5172,7 +5279,20 @@
 									}
 								}
 							]
-                        },
+						},
+						{
+							"name": "DialogApi",
+							"apiVersion": "1.2",
+							"availability": "GA",
+							"supportedProductVersions": [
+								{
+									"from": {
+										"build": "16.0.12527.20720",
+										"version": null
+									}
+								}
+							]
+						},
 						{
 							"name": "IdentityAPI",
 							"apiVersion": "1.1",

--- a/mapping/requirements_officejs.json
+++ b/mapping/requirements_officejs.json
@@ -175,7 +175,7 @@
 							"apiVersion": "1.2",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "2.37.504.0",
+									"build": "16.37.0.0",
 									"version": null
 								}
 							}],
@@ -843,7 +843,7 @@
 							"apiVersion": "1.2",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "16.37.20051002",
+									"build": "16.37.510.0",
 									"version": null
 								}
 							}],
@@ -2275,7 +2275,7 @@
 							"apiVersion": "1.2",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "2.37.504.0",
+									"build": "16.37.0.0",
 									"version": null
 								}
 							}],
@@ -3063,7 +3063,7 @@
 							"apiVersion": "1.2",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "16.37.20051002",
+									"build": "16.37.510.0",
 									"version": null
 								}
 							}],
@@ -4717,7 +4717,7 @@
 							"apiVersion": "1.2",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "2.37.504.0",
+									"build": "16.37.0.0",
 									"version": null
 								}
 							}],
@@ -4919,7 +4919,7 @@
 							"apiVersion": "1.2",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "16.37.20051002",
+									"build": "16.37.510.0",
 									"version": null
 								}
 							}],


### PR DESCRIPTION
Update the requirement set for Dialog API 1.2.

Use the following version number:
Win32:  16.0.12527.20720
Mac: 16.37.510.0
iOS: 16.37.0.0
Office Online: n/a