### PR TITLE
Add RibbonApi GA requirements for Excel Online

### DIFF
--- a/mapping/requirements_officejs.json
+++ b/mapping/requirements_officejs.json
@@ -2024,6 +2024,11 @@
 							"name": "CustomFunctionsRuntime",
 							"apiVersion": "1.1",
 							"availability": "GA"
+						},
+						{
+							"name": "RibbonApi",
+							"apiVersion": "1.1",
+							"availability": "GA"
 						}
 					],
 					"supportedMethods": [{


### PR DESCRIPTION
Ribbon Enable/Disable JS API is ready GA for ExcelOnline, add Requirement Set RibbonApi in SoT.