### PR TITLE
OpenBrowserWindowApi backfill

### DIFF
--- a/mapping/requirements_officejs.json
+++ b/mapping/requirements_officejs.json
@@ -149,7 +149,18 @@
 								}
 							],
 							"availability": "GA"
-						},
+                        },
+						{
+							"name": "OpenBrowserWindowApi",
+							"apiVersion": "1.1",
+							"supportedProductVersions": [{
+								"from": {
+									"build": "16.0.0.0",
+									"version": null
+								}
+							}],
+							"availability": "GA"
+						},                        
 						{
 							"name": "File",
 							"apiVersion": "1.1",
@@ -826,6 +837,17 @@
 							"supportedProductVersions": [{
 								"from": {
 									"build": "16.38.0.0",
+									"version": null
+								}
+							}],
+							"availability": "GA"
+						},
+						{
+							"name": "OpenBrowserWindowApi",
+							"apiVersion": "1.1",
+							"supportedProductVersions": [{
+								"from": {
+									"build": "16.0.0.0",
 									"version": null
 								}
 							}],
@@ -1585,7 +1607,18 @@
 								}
 							],
 							"availability": "GA"
-						},
+                        },
+						{
+							"name": "OpenBrowserWindowApi",
+							"apiVersion": "1.1",
+							"supportedProductVersions": [{
+								"from": {
+									"build": "16.0.8201.2001",
+									"version": "1704"
+								}
+							}],
+							"availability": "GA"
+						},                        
 						{
 							"name": "SharedRuntime",
 							"apiVersion": "1.1",
@@ -2022,7 +2055,7 @@
 							"name": "ExcelApi",
 							"apiVersion": "1.12",
 							"availability": "GA"
-						},
+                        },                       
 						{
 							"name": "SharedRuntime",
 							"apiVersion": "1.1",
@@ -2361,7 +2394,18 @@
 								}
 							}],
 							"availability": "GA"
-						},
+                        },
+						{
+							"name": "OpenBrowserWindowApi",
+							"apiVersion": "1.1",
+							"supportedProductVersions": [{
+								"from": {
+									"build": "16.0.0.0",
+									"version": null
+								}
+							}],
+							"availability": "GA"
+						},                        
 						{
 							"name": "DialogApi",
 							"apiVersion": "1.1",
@@ -3149,7 +3193,18 @@
 								}
 							}],
 							"availability": "GA"
-						},
+                        },
+						{
+							"name": "OpenBrowserWindowApi",
+							"apiVersion": "1.1",
+							"supportedProductVersions": [{
+								"from": {
+									"build": "16.0.0.0",
+									"version": null
+								}
+							}],
+							"availability": "GA"
+						},                        
 						{
 							"name": "DialogApi",
 							"apiVersion": "1.1",
@@ -3963,7 +4018,7 @@
 							"name": "WordApi",
 							"apiVersion": "1.3",
 							"availability": "GA"
-						},
+                        },                       
 						{
 							"name": "DialogApi",
 							"apiVersion": "1.1",
@@ -4380,6 +4435,17 @@
 						{
 							"name": "WordApi",
 							"apiVersion": "1.3",
+							"supportedProductVersions": [{
+								"from": {
+									"build": "16.0.7668.1000",
+									"version": "1612"
+								}
+							}],
+							"availability": "GA"
+						},
+						{
+							"name": "OpenBrowserWindowApi",
+							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
 									"build": "16.0.7668.1000",
@@ -4857,7 +4923,18 @@
 							"name": "TextCoercion",
 							"apiVersion": "1.1",
 							"availability": "GA"
-						},
+                        },
+						{
+							"name": "OpenBrowserWindowApi",
+							"apiVersion": "1.1",
+							"supportedProductVersions": [{
+								"from": {
+									"build": "16.0.0.0",
+									"version": null
+								}
+							}],
+							"availability": "GA"
+						},                        
 						{
 							"name": "DialogApi",
 							"apiVersion": "1.1",
@@ -5037,7 +5114,18 @@
 							"name": "AddinCommands",
 							"apiVersion": "1.1",
 							"availability": "GA"
-						},
+                        },
+						{
+							"name": "OpenBrowserWindowApi",
+							"apiVersion": "1.1",
+							"supportedProductVersions": [{
+								"from": {
+									"build": "16.0.0.0",
+									"version": null
+								}
+							}],
+							"availability": "GA"
+						},                        
 						{
 							"name": "DialogApi",
 							"apiVersion": "1.1",
@@ -5232,7 +5320,7 @@
 							"name": "Selection",
 							"apiVersion": "1.1",
 							"availability": "GA"
-						},
+                        },                      
 						{
 							"name": "Settings",
 							"apiVersion": "1.1",
@@ -5427,6 +5515,17 @@
 						},
 						{
 							"name": "PowerPointApi",
+							"apiVersion": "1.1",
+							"supportedProductVersions": [{
+								"from": {
+									"build": "16.0.11001.20074",
+									"version": "1810"
+								}
+							}],
+							"availability": "GA"
+						},
+						{
+							"name": "OpenBrowserWindowApi",
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
@@ -6084,7 +6183,18 @@
 								}
 							}],
 							"availability": "GA"
-						}
+                        },
+						{
+							"name": "OpenBrowserWindowApi",
+							"apiVersion": "1.1",
+							"supportedProductVersions": [{
+								"from": {
+									"build": "15.1.990.0",
+									"version": null
+								}
+							}],
+							"availability": "GA"
+						}                        
 					],
 					"supportedMethods": []
 				},
@@ -6213,7 +6323,18 @@
 								}
 							}],
 							"availability": "GA"
-						}
+                        },
+						{
+							"name": "OpenBrowserWindowApi",
+							"apiVersion": "1.1",
+							"supportedProductVersions": [{
+								"from": {
+									"build": "16.0.0.0",
+									"version": null
+								}
+							}],
+							"availability": "GA"
+						}                        
 					],
 					"supportedMethods": []
 				},
@@ -6298,7 +6419,18 @@
 								}
 							}],
 							"availability": "GA"
-						}
+                        },
+						{
+							"name": "OpenBrowserWindowApi",
+							"apiVersion": "1.1",
+							"supportedProductVersions": [{
+								"from": {
+									"build": "16.0.0.0",
+									"version": null
+								}
+							}],
+							"availability": "GA"
+						}                        
 					],
 					"supportedMethods": []
 				},
@@ -6503,7 +6635,7 @@
 								}
 							}],
 							"availability": "GA"
-						}
+                        }                       
 					],
 					"supportedMethods": []
 				}

--- a/mapping/requirements_officejs.json
+++ b/mapping/requirements_officejs.json
@@ -1613,7 +1613,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "16.0.8201.2001",
+									"build": "16.0.11001.20074",
 									"version": "1704"
 								}
 							}],
@@ -4448,7 +4448,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "16.0.7668.1000",
+									"build": "16.0.11001.20074",
 									"version": "1612"
 								}
 							}],
@@ -6189,7 +6189,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.1.990.0",
+									"build": "15.20.3300.0",
 									"version": null
 								}
 							}],
@@ -6329,7 +6329,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "16.0.0.0",
+									"build": "15.20.3300.0",
 									"version": null
 								}
 							}],
@@ -6425,7 +6425,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "16.0.0.0",
+									"build": "15.1.990.0",
 									"version": null
 								}
 							}],


### PR DESCRIPTION
Name of the requirement-set: OpenBrowserWindowApi
Platforms: Windows, iOS, Mac. 
Hosts: W/X/P/Outlook
Versions: For build versions for Windows/Mac/iOS: in the platform it’s been implemented for years. So, a older versions of each platform is picked as a way to allow this to work. We do not have a specific build# when this was implemented. If we run into any quality issues with that, we'll adjust accordingly