### PR TITLE
Move PowerPoint Online AddinCommands to 1.3

### DIFF
--- a/mapping/requirements_officejs.json
+++ b/mapping/requirements_officejs.json
@@ -70,7 +70,7 @@
 								}
 							}],
 							"availability": "GA"
-						},		     
+						},
 						{
 							"name": "ExcelApi",
 							"apiVersion": "1.6",
@@ -160,7 +160,7 @@
 								}
 							}],
 							"availability": "GA"
-						},                        
+						},
 						{
 							"name": "File",
 							"apiVersion": "1.1",
@@ -762,7 +762,7 @@
 								}
 							}],
 							"availability": "GA"
-						},  
+						},
 						{
 							"name": "ExcelApi",
 							"apiVersion": "1.7",
@@ -1640,7 +1640,7 @@
 								}
 							}],
 							"availability": "GA"
-						},                        
+						},
 						{
 							"name": "SharedRuntime",
 							"apiVersion": "1.1",
@@ -2099,7 +2099,7 @@
 							"name": "ExcelApi",
 							"apiVersion": "1.12",
 							"availability": "GA"
-                        },                       
+                        },
 						{
 							"name": "SharedRuntime",
 							"apiVersion": "1.1",
@@ -2459,7 +2459,7 @@
 								}
 							}],
 							"availability": "GA"
-						},                        
+						},
 						{
 							"name": "DialogApi",
 							"apiVersion": "1.1",
@@ -3258,7 +3258,7 @@
 								}
 							}],
 							"availability": "GA"
-						},                        
+						},
 						{
 							"name": "DialogApi",
 							"apiVersion": "1.1",
@@ -4072,7 +4072,7 @@
 							"name": "WordApi",
 							"apiVersion": "1.3",
 							"availability": "GA"
-                        },                       
+                        },
 						{
 							"name": "DialogApi",
 							"apiVersion": "1.1",
@@ -4988,7 +4988,7 @@
 								}
 							}],
 							"availability": "GA"
-						},                        
+						},
 						{
 							"name": "DialogApi",
 							"apiVersion": "1.1",
@@ -5021,7 +5021,7 @@
 								}
 							}],
 							"availability": "GA"
-                        }                        
+                        }
 					],
 					"supportedMethods": [{
 							"name": "Document.addHandlerAsync",
@@ -5179,7 +5179,7 @@
 								}
 							}],
 							"availability": "GA"
-						},                        
+						},
 						{
 							"name": "DialogApi",
 							"apiVersion": "1.1",
@@ -5256,7 +5256,7 @@
 								}
 							}],
 							"availability": "GA"
-                        }                          
+                        }
 					],
 					"supportedMethods": [{
 							"name": "Document.addHandlerAsync",
@@ -5352,7 +5352,7 @@
 						},
 						{
 							"name": "AddinCommands",
-							"apiVersion": "1.1",
+							"apiVersion": "1.3",
 							"availability": "GA"
 						},
 						{
@@ -5374,7 +5374,7 @@
 							"name": "Selection",
 							"apiVersion": "1.1",
 							"availability": "GA"
-                        },                      
+                        },
 						{
 							"name": "Settings",
 							"apiVersion": "1.1",
@@ -6248,7 +6248,7 @@
 								}
 							}],
 							"availability": "GA"
-						}                        
+						}
 					],
 					"supportedMethods": []
 				},
@@ -6388,7 +6388,7 @@
 								}
 							}],
 							"availability": "GA"
-						}                        
+						}
 					],
 					"supportedMethods": []
 				},
@@ -6484,7 +6484,7 @@
 								}
 							}],
 							"availability": "GA"
-						}                        
+						}
 					],
 					"supportedMethods": []
 				},
@@ -6689,7 +6689,7 @@
 								}
 							}],
 							"availability": "GA"
-                        }                       
+                        }
 					],
 					"supportedMethods": []
 				}


### PR DESCRIPTION
Bumping up AddinCommands requirement set for PowerPoint Online from 1.1 to 1.3:
AddinCommands 1.2: Remove the 6 controls limit under control groups of custom Ribbon tabs.
AddinCommands 1.3: New manifest elements like OfficeGroup, OfficeControl, InsertBefore and InsertAfter.