### PR TITLE
DialogApi 1.1 Windows version range addition

### DIFF
--- a/mapping/requirements_officejs.json
+++ b/mapping/requirements_officejs.json
@@ -5614,24 +5614,24 @@
 							"apiVersion": "1.1",
 							"availability": "GA",
 							"supportedProductVersions": [{
-									"from": {
-										"build": "15.0.4855.1000",
-										"version": null
-									},
-									"to": {
-										"build": "15.9.9999.9999",
-										"version": null
-									}
-								},
-								{
-									"from": {
-										"build": "16.0.4390.1000",
-										"version": null
+                                "from": {
+                                    "build": "15.0.4855.1000",
+                                    "version": null
+                                },
+                                "to": {
+                                    "build": "15.9.9999.9999",
+                                    "version": null
+                                    }
+                                },
+                                {
+                                    "from": {
+                                        "build": "16.0.4390.1000",
+                                        "version": null
                                     },
-									"to": {
-										"build": "16.0.5999.1000",
-										"version": null
-									}                                    
+                                    "to": {
+                                        "build": "16.0.5999.1000",
+                                        "version": null
+                                    }                                    
                                 },
                                 {
                                     "from": {

--- a/mapping/requirements_officejs.json
+++ b/mapping/requirements_officejs.json
@@ -1700,21 +1700,31 @@
 							"name": "DialogApi",
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
-									"from": {
-										"build": "15.0.4855.1000",
-										"version": null
-									},
-									"to": {
-										"build": "15.9.9999.9999",
-										"version": null
-									}
-								},
-								{
-									"from": {
-										"build": "16.0.6741.0000",
-										"version": "1602"
-									}
-								}
+                                "from": {
+                                    "build": "15.0.4855.1000",
+                                    "version": null
+                                },
+                                "to": {
+                                    "build": "15.9.9999.9999",
+                                    "version": null
+                                    }
+                                },
+                                {
+                                    "from": {
+                                        "build": "16.0.4390.1000",
+                                        "version": null
+                                    },
+                                    "to": {
+                                        "build": "16.0.5999.1000",
+                                        "version": null
+                                    }                                    
+                                },
+                                {
+                                    "from": {
+                                        "build": "16.0.6741.0000",
+                                        "version": "1602"
+                                    }
+                                }
 							],
 							"availability": "GA"
 						},
@@ -4512,21 +4522,31 @@
 							"name": "DialogApi",
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
-									"from": {
-										"build": "15.0.4855.1000",
-										"version": null
-									},
-									"to": {
-										"build": "15.9.9999.9999",
-										"version": null
-									}
-								},
-								{
-									"from": {
-										"build": "16.0.6741.0000",
-										"version": "1602"
-									}
-								}
+                                "from": {
+                                    "build": "15.0.4855.1000",
+                                    "version": null
+                                },
+                                "to": {
+                                    "build": "15.9.9999.9999",
+                                    "version": null
+                                    }
+                                },
+                                {
+                                    "from": {
+                                        "build": "16.0.4390.1000",
+                                        "version": null
+                                    },
+                                    "to": {
+                                        "build": "16.0.5999.1000",
+                                        "version": null
+                                    }                                    
+                                },
+                                {
+                                    "from": {
+                                        "build": "16.0.6741.0000",
+                                        "version": "1602"
+                                    }
+                                }
 							],
 							"availability": "GA"
 						},
@@ -5196,8 +5216,8 @@
 								},
 								{
 									"from": {
-										"build": "16.0.6741.0000",
-										"version": "1602"
+										"build": "16.0.0.0",
+										"version": null
 									}
 								}
 							]
@@ -5605,10 +5625,20 @@
 								},
 								{
 									"from": {
-										"build": "16.0.6741.0000",
-										"version": "1602"
-									}
-								}
+										"build": "16.0.4390.1000",
+										"version": null
+                                    },
+									"to": {
+										"build": "16.0.5999.1000",
+										"version": null
+									}                                    
+                                },
+                                {
+                                    "from": {
+                                        "build": "16.0.6741.0000",
+                                        "version": "1602"
+                                    }
+                                }
 							]
 						},
 						{


### PR DESCRIPTION
This is to add the missing range 
                                    "from": {
                                        "build": "16.0.4390.1000",
                                        "version": null
                                    },
                                    "to": {
                                        "build": "16.0.5999.1000",
                                        "version": null
                                    }  