### PR TITLE
updating RibbonAPI version 1.2 (November 2020 Fork)

### DIFF
--- a/mapping/requirements_officejs.json
+++ b/mapping/requirements_officejs.json
@@ -1122,7 +1122,7 @@
 							"apiVersion": "1.2",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "16.43.0.0",
+									"build": "16.44.0.0",
 									"version": null
 								}
 							}],
@@ -1877,7 +1877,7 @@
 							"apiVersion": "1.2",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "16.0.13427.20000",
+									"build": "16.0.13519.20000",
 									"version": null
 								}
 							}],


### PR DESCRIPTION
Updating Office JS requirement sets for Ribbon API 1.2 for both Win and Mac.