### PR TITLE
Fix PowerPointApi1.2 GA versions

### DIFF
--- a/mapping/requirements_officejs.json
+++ b/mapping/requirements_officejs.json
@@ -5052,18 +5052,7 @@
 								}
 							}],
 							"availability": "GA"
-                        },
-						{
-							"name": "PowerPointApi",
-							"apiVersion": "1.2",
-							"supportedProductVersions": [{
-								"from": {
-									"build": "16.43.0.0",
-									"version": null
-								}
-							}],
-							"availability": "GA"
-                        }
+						}
 					],
 					"supportedMethods": [{
 							"name": "Document.addHandlerAsync",
@@ -5298,18 +5287,18 @@
 								}
 							}],
 							"availability": "GA"
-                        },
+						},
 						{
 							"name": "PowerPointApi",
 							"apiVersion": "1.2",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "16.0.13426.20184",
+									"build": "16.43.0.0",
 									"version": null
 								}
 							}],
 							"availability": "GA"
-                        }
+						}
 					],
 					"supportedMethods": [{
 							"name": "Document.addHandlerAsync",
@@ -5637,6 +5626,17 @@
 								"from": {
 									"build": "16.0.11001.20074",
 									"version": "1810"
+								}
+							}],
+							"availability": "GA"
+						},
+						{
+							"name": "PowerPointApi",
+							"apiVersion": "1.2",
+							"supportedProductVersions": [{
+								"from": {
+									"build": "16.0.13426.20184",
+									"version": null
 								}
 							}],
 							"availability": "GA"


### PR DESCRIPTION
The version numbers added for PowerPointApi1.2 were placed at wrong locations with the previous checkin: https://github.com/OfficeDev/Office-Js-Requirement-Sets/pull/77
This change updates the version numbers to the correct platforms and versions.

Platform | Old PowerPointApi1.2 version | Updated PowerPoint1.2 version
-- | -- | --
ios | 16.43.0.0 | Should not be supported
Mac | 16.0.13426.20184 | 16.43.0.0
Wac | GA | GA
Win32 | Not supported | 16.0.13426.20184
