### PR TITLE
Add AddinCommands 1.2 requirement set to Word Online and Excel Online.

### DIFF
--- a/mapping/requirements_officejs.json
+++ b/mapping/requirements_officejs.json
@@ -2198,6 +2198,11 @@
 							"availability": "GA"
 						},
 						{
+							"name": "AddinCommands",
+							"apiVersion": "1.2",
+							"availability": "GA"
+						},
+						{
 							"name": "MatrixBindings",
 							"apiVersion": "1.1",
 							"availability": "GA"
@@ -4264,6 +4269,11 @@
 						{
 							"name": "AddinCommands",
 							"apiVersion": "1.1",
+							"availability": "GA"
+						},
+						{
+							"name": "AddinCommands",
+							"apiVersion": "1.2",
 							"availability": "GA"
 						}
 					],


### PR DESCRIPTION
Add AddinCommands 1.2 requirement set to Word Online and Excel Online for relaxing the button number limitation in Office ribbon.