### PR TITLE
Add PowerPointApi1.3 GA versions

### DIFF
--- a/mapping/requirements_officejs.json
+++ b/mapping/requirements_officejs.json
@@ -5464,6 +5464,17 @@
 								}
 							}],
 							"availability": "GA"
+						},
+						{
+							"name": "PowerPointApi",
+							"apiVersion": "1.3",
+							"supportedProductVersions": [{
+								"from": {
+									"build": "16.55.0.0",
+									"version": null
+								}
+							}],
+							"availability": "GA"
 						}
 					],
 					"supportedMethods": [{
@@ -5626,6 +5637,11 @@
 						{
 							"name": "PowerPointApi",
 							"apiVersion": "1.2",
+							"availability": "GA"
+						},
+						{
+							"name": "PowerPointApi",
+							"apiVersion": "1.3",
 							"availability": "GA"
 						},
 						{
@@ -5812,6 +5828,17 @@
 							"supportedProductVersions": [{
 								"from": {
 									"build": "16.0.13426.20184",
+									"version": null
+								}
+							}],
+							"availability": "GA"
+						},
+						{
+							"name": "PowerPointApi",
+							"apiVersion": "1.3",
+							"supportedProductVersions": [{
+								"from": {
+									"build": "16.0.14701.20060",
 									"version": null
 								}
 							}],


### PR DESCRIPTION
Add `PowerPointApi1.3` build numbers for different platforms to release `PowerPointApi1.3` to GA.

| Platform | Supported Version |
| ------------- | ------------- |
| Web | GA |
| Win32 | 16.0.14701.20060 |
| Mac | 16.55.0.0 |
| ios | Not supported |