### PR TITLE
Add Mailbox 1.11 Requirement Set for Outlook for Windows

### DIFF
--- a/mapping/requirements_officejs.json
+++ b/mapping/requirements_officejs.json
@@ -6513,7 +6513,7 @@
 								}
 							}],
 							"availability": "GA"
-                        			},
+						},
 						{
 							"name": "Mailbox",
 							"apiVersion": "1.10",
@@ -6524,7 +6524,18 @@
 								}
 							}],
 							"availability": "GA"
-                        			},
+						},
+						{
+							"name": "Mailbox",
+							"apiVersion": "1.11",
+							"supportedProductVersions": [{
+								"from": {
+									"build": "15.20.4871.0",
+									"version": null
+								}
+							}],
+							"availability": "GA"
+						},
 						{
 							"name": "OpenBrowserWindowApi",
 							"apiVersion": "1.1",
@@ -6976,7 +6987,7 @@
 								}
 							}],
 							"availability": "GA"
-                        			},
+						},
 						{
 							"name": "Mailbox",
 							"apiVersion": "1.10",
@@ -6987,7 +6998,7 @@
 								}
 							}],
 							"availability": "GA"
-                        			}
+						}
 					],
 					"supportedMethods": []
 				}


### PR DESCRIPTION
Mailbox Requirement Set 1.11 for Outlook for Windows has GA'ed, so we need to add it to our list of supported requirement sets.