### PR TITLE
Add 1.10 Requirement Set for Outlook for Mac

### DIFF
--- a/mapping/requirements_officejs.json
+++ b/mapping/requirements_officejs.json
@@ -6753,7 +6753,18 @@
 								}
 							}],
 							"availability": "GA"
-                        },
+						},
+						{
+							"name": "Mailbox",
+							"apiVersion": "1.10",
+							"supportedProductVersions": [{
+								"from": {
+									"build": "15.20.3863.0",
+									"version": null
+								}
+							}],
+							"availability": "GA"
+						},
 						{
 							"name": "OpenBrowserWindowApi",
 							"apiVersion": "1.1",


### PR DESCRIPTION
Updating 1.10 requirement set for Outlook for Mac. Server version is same as Outlook for Windows.