### PR TITLE
Add PowerPointApi1.4 GA versions

### DIFF
--- a/mapping/requirements_officejs.json
+++ b/mapping/requirements_officejs.json
@@ -5543,6 +5543,17 @@
 								}
 							}],
 							"availability": "GA"
+						},
+						{
+							"name": "PowerPointApi",
+							"apiVersion": "1.4",
+							"supportedProductVersions": [{
+								"from": {
+									"build": "16.62.0.0",
+									"version": null
+								}
+							}],
+							"availability": "GA"
 						}
 					],
 					"supportedMethods": [{
@@ -5710,6 +5721,11 @@
 						{
 							"name": "PowerPointApi",
 							"apiVersion": "1.3",
+							"availability": "GA"
+						},
+						{
+							"name": "PowerPointApi",
+							"apiVersion": "1.4",
 							"availability": "GA"
 						},
 						{
@@ -5917,6 +5933,17 @@
 							"supportedProductVersions": [{
 								"from": {
 									"build": "16.0.14701.20060",
+									"version": null
+								}
+							}],
+							"availability": "GA"
+						},
+						{
+							"name": "PowerPointApi",
+							"apiVersion": "1.4",
+							"supportedProductVersions": [{
+								"from": {
+									"build": "16.0.15330.20122",
 									"version": null
 								}
 							}],


### PR DESCRIPTION
The following are updated as supported versions in PowerPointApi set 1.4
Win32: 16.0.15330.20122
Mac: 16.62
Web: GA (May 2022)