### PR TITLE
Bypass Filtering of manifests for api sets on Outlook-mobile Addins 

### DIFF
--- a/mapping/requirements_officejs.json
+++ b/mapping/requirements_officejs.json
@@ -7230,7 +7230,84 @@
 								}
 							}],
 							"availability": "GA"
-                        },
+                        			},
+						{
+							"name": "Mailbox",
+							"apiVersion": "1.6",
+							"supportedProductVersions": [{
+								"from": {
+									"build": "15.1.990.0",
+									"version": null
+								}
+							}],
+							"availability": "GA"
+                        			},
+						{
+							"name": "Mailbox",
+							"apiVersion": "1.7",
+							"supportedProductVersions": [{
+								"from": {
+									"build": "15.1.990.0",
+									"version": null
+								}
+							}],
+							"availability": "GA"
+                        			},
+						{
+							"name": "Mailbox",
+							"apiVersion": "1.8",
+							"supportedProductVersions": [{
+								"from": {
+									"build": "15.1.990.0",
+									"version": null
+								}
+							}],
+							"availability": "GA"
+                        			},
+						{
+							"name": "Mailbox",
+							"apiVersion": "1.9",
+							"supportedProductVersions": [{
+								"from": {
+									"build": "15.1.990.0",
+									"version": null
+								}
+							}],
+							"availability": "GA"
+                        			},
+						{
+							"name": "Mailbox",
+							"apiVersion": "1.10",
+							"supportedProductVersions": [{
+								"from": {
+									"build": "15.1.990.0",
+									"version": null
+								}
+							}],
+							"availability": "GA"
+                        			},
+						{
+							"name": "Mailbox",
+							"apiVersion": "1.11",
+							"supportedProductVersions": [{
+								"from": {
+									"build": "15.1.990.0",
+									"version": null
+								}
+							}],
+							"availability": "GA"
+                        			},
+						{
+							"name": "Mailbox",
+							"apiVersion": "1.12",
+							"supportedProductVersions": [{
+								"from": {
+									"build": "15.1.990.0",
+									"version": null
+								}
+							}],
+							"availability": "GA"
+                        			},
 						{
 							"name": "OpenBrowserWindowApi",
 							"apiVersion": "1.1",

--- a/mapping/requirements_officejs.json
+++ b/mapping/requirements_officejs.json
@@ -7317,6 +7317,83 @@
 								}
 							}],
 							"availability": "GA"
+						},
+						{
+							"name": "Mailbox",
+							"apiVersion": "1.6",
+							"supportedProductVersions": [{
+								"from": {
+									"build": "16.0.8414.0",
+									"version": null
+								}
+							}],
+							"availability": "GA"
+						},
+						{
+							"name": "Mailbox",
+							"apiVersion": "1.7",
+							"supportedProductVersions": [{
+								"from": {
+									"build": "16.0.8414.0",
+									"version": null
+								}
+							}],
+							"availability": "GA"
+						},
+						{
+							"name": "Mailbox",
+							"apiVersion": "1.8",
+							"supportedProductVersions": [{
+								"from": {
+									"build": "16.0.8414.0",
+									"version": null
+								}
+							}],
+							"availability": "GA"
+						},
+						{
+							"name": "Mailbox",
+							"apiVersion": "1.9",
+							"supportedProductVersions": [{
+								"from": {
+									"build": "16.0.8414.0",
+									"version": null
+								}
+							}],
+							"availability": "GA"
+						},
+						{
+							"name": "Mailbox",
+							"apiVersion": "1.10",
+							"supportedProductVersions": [{
+								"from": {
+									"build": "16.0.8414.0",
+									"version": null
+								}
+							}],
+							"availability": "GA"
+						},
+						{
+							"name": "Mailbox",
+							"apiVersion": "1.11",
+							"supportedProductVersions": [{
+								"from": {
+									"build": "16.0.8414.0",
+									"version": null
+								}
+							}],
+							"availability": "GA"
+						},
+						{
+							"name": "Mailbox",
+							"apiVersion": "1.12",
+							"supportedProductVersions": [{
+								"from": {
+									"build": "16.0.8414.0",
+									"version": null
+								}
+							}],
+							"availability": "GA"
 						}
 					],
 					"supportedMethods": []


### PR DESCRIPTION
For Outlook Mobile we support api-sets till 1.5 and after that we support selective APIs from further api-sets. To let the same add-in work across platforms, we need to make sure that add-ins which mention higher API sets in their manifests, also work for mobile. Therefore corresponding entries have been made to bypass the filtering process for mobile.
