### PR TITLE
Update to add 1.13 API set for Outlook Mac

### DIFF
--- a/mapping/requirements_officejs.json
+++ b/mapping/requirements_officejs.json
@@ -7136,6 +7136,17 @@
 							"availability": "GA"
 						},
 						{
+							"name": "Mailbox",
+							"apiVersion": "1.13",
+							"supportedProductVersions": [{
+								"from": {
+									"build": "15.20.6226.0",
+									"version": null
+								}
+							}],
+							"availability": "GA"
+						},
+						{
 							"name": "OpenBrowserWindowApi",
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{


### PR DESCRIPTION
Update requirements_officejs.json to add 1.13 API set support for Outlook Mac