### PR TITLE
Add 1.13 API set to Outlook iOS and Android to bypass filtering of manifests on Outlook Mobile

### DIFF
--- a/mapping/requirements_officejs.json
+++ b/mapping/requirements_officejs.json
@@ -7306,95 +7306,95 @@
 								}
 							}],
 							"availability": "GA"
-						},
+                        			},
 						{
 							"name": "Mailbox",
 							"apiVersion": "1.6",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.20.0441.0",
+									"build": "15.1.990.0",
 									"version": null
 								}
 							}],
 							"availability": "GA"
-						},
+                        			},
 						{
 							"name": "Mailbox",
 							"apiVersion": "1.7",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.20.1063.0",
+									"build": "15.1.990.0",
 									"version": null
 								}
 							}],
 							"availability": "GA"
-						},
+                        			},
 						{
 							"name": "Mailbox",
 							"apiVersion": "1.8",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.20.2078.0",
+									"build": "15.1.990.0",
 									"version": null
 								}
 							}],
 							"availability": "GA"
-						},
+                        			},
 						{
 							"name": "Mailbox",
 							"apiVersion": "1.9",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.20.3233.0",
+									"build": "15.1.990.0",
 									"version": null
 								}
 							}],
 							"availability": "GA"
-						},
+                        			},
 						{
 							"name": "Mailbox",
 							"apiVersion": "1.10",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.20.3863.0",
+									"build": "15.1.990.0",
 									"version": null
 								}
 							}],
 							"availability": "GA"
-						},
+                        			},
 						{
 							"name": "Mailbox",
 							"apiVersion": "1.11",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.20.4871.0",
+									"build": "15.1.990.0",
 									"version": null
 								}
 							}],
 							"availability": "GA"
-						},
+                        			},
 						{
 							"name": "Mailbox",
 							"apiVersion": "1.12",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.20.5389.0",
+									"build": "15.1.990.0",
 									"version": null
 								}
 							}],
 							"availability": "GA"
-						},
+                        			},
 						{
 							"name": "Mailbox",
 							"apiVersion": "1.13",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.20.6226.0",
+									"build": "15.1.990.0",
 									"version": null
 								}
 							}],
 							"availability": "GA"
-						},
+                        			},
 						{
 							"name": "OpenBrowserWindowApi",
 							"apiVersion": "1.1",
@@ -7476,7 +7476,7 @@
 							"apiVersion": "1.5",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.1.990.0",
+									"build": "16.0.8414.0",
 									"version": null
 								}
 							}],
@@ -7487,7 +7487,7 @@
 							"apiVersion": "1.6",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.20.0441.0",
+									"build": "16.0.8414.0",
 									"version": null
 								}
 							}],
@@ -7498,7 +7498,7 @@
 							"apiVersion": "1.7",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.20.1063.0",
+									"build": "16.0.8414.0",
 									"version": null
 								}
 							}],
@@ -7509,7 +7509,7 @@
 							"apiVersion": "1.8",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.20.2078.0",
+									"build": "16.0.8414.0",
 									"version": null
 								}
 							}],
@@ -7520,7 +7520,7 @@
 							"apiVersion": "1.9",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.20.3233.0",
+									"build": "16.0.8414.0",
 									"version": null
 								}
 							}],
@@ -7531,7 +7531,7 @@
 							"apiVersion": "1.10",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.20.3863.0",
+									"build": "16.0.8414.0",
 									"version": null
 								}
 							}],
@@ -7542,7 +7542,7 @@
 							"apiVersion": "1.11",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.20.4871.0",
+									"build": "16.0.8414.0",
 									"version": null
 								}
 							}],
@@ -7553,7 +7553,7 @@
 							"apiVersion": "1.12",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.20.5389.0",
+									"build": "16.0.8414.0",
 									"version": null
 								}
 							}],
@@ -7564,7 +7564,7 @@
 							"apiVersion": "1.13",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.20.6226.0",
+									"build": "16.0.8414.0",
 									"version": null
 								}
 							}],

--- a/mapping/requirements_officejs.json
+++ b/mapping/requirements_officejs.json
@@ -7306,84 +7306,95 @@
 								}
 							}],
 							"availability": "GA"
-                        			},
+						},
 						{
 							"name": "Mailbox",
 							"apiVersion": "1.6",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.1.990.0",
+									"build": "15.20.0441.0",
 									"version": null
 								}
 							}],
 							"availability": "GA"
-                        			},
+						},
 						{
 							"name": "Mailbox",
 							"apiVersion": "1.7",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.1.990.0",
+									"build": "15.20.1063.0",
 									"version": null
 								}
 							}],
 							"availability": "GA"
-                        			},
+						},
 						{
 							"name": "Mailbox",
 							"apiVersion": "1.8",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.1.990.0",
+									"build": "15.20.2078.0",
 									"version": null
 								}
 							}],
 							"availability": "GA"
-                        			},
+						},
 						{
 							"name": "Mailbox",
 							"apiVersion": "1.9",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.1.990.0",
+									"build": "15.20.3233.0",
 									"version": null
 								}
 							}],
 							"availability": "GA"
-                        			},
+						},
 						{
 							"name": "Mailbox",
 							"apiVersion": "1.10",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.1.990.0",
+									"build": "15.20.3863.0",
 									"version": null
 								}
 							}],
 							"availability": "GA"
-                        			},
+						},
 						{
 							"name": "Mailbox",
 							"apiVersion": "1.11",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.1.990.0",
+									"build": "15.20.4871.0",
 									"version": null
 								}
 							}],
 							"availability": "GA"
-                        			},
+						},
 						{
 							"name": "Mailbox",
 							"apiVersion": "1.12",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "15.1.990.0",
+									"build": "15.20.5389.0",
 									"version": null
 								}
 							}],
 							"availability": "GA"
-                        			},
+						},
+						{
+							"name": "Mailbox",
+							"apiVersion": "1.13",
+							"supportedProductVersions": [{
+								"from": {
+									"build": "15.20.6226.0",
+									"version": null
+								}
+							}],
+							"availability": "GA"
+						},
 						{
 							"name": "OpenBrowserWindowApi",
 							"apiVersion": "1.1",
@@ -7465,7 +7476,7 @@
 							"apiVersion": "1.5",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "16.0.8414.0",
+									"build": "15.1.990.0",
 									"version": null
 								}
 							}],
@@ -7476,7 +7487,7 @@
 							"apiVersion": "1.6",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "16.0.8414.0",
+									"build": "15.20.0441.0",
 									"version": null
 								}
 							}],
@@ -7487,7 +7498,7 @@
 							"apiVersion": "1.7",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "16.0.8414.0",
+									"build": "15.20.1063.0",
 									"version": null
 								}
 							}],
@@ -7498,7 +7509,7 @@
 							"apiVersion": "1.8",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "16.0.8414.0",
+									"build": "15.20.2078.0",
 									"version": null
 								}
 							}],
@@ -7509,7 +7520,7 @@
 							"apiVersion": "1.9",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "16.0.8414.0",
+									"build": "15.20.3233.0",
 									"version": null
 								}
 							}],
@@ -7520,7 +7531,7 @@
 							"apiVersion": "1.10",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "16.0.8414.0",
+									"build": "15.20.3863.0",
 									"version": null
 								}
 							}],
@@ -7531,7 +7542,7 @@
 							"apiVersion": "1.11",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "16.0.8414.0",
+									"build": "15.20.4871.0",
 									"version": null
 								}
 							}],
@@ -7542,7 +7553,18 @@
 							"apiVersion": "1.12",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "16.0.8414.0",
+									"build": "15.20.5389.0",
+									"version": null
+								}
+							}],
+							"availability": "GA"
+						},
+						{
+							"name": "Mailbox",
+							"apiVersion": "1.13",
+							"supportedProductVersions": [{
+								"from": {
+									"build": "15.20.6226.0",
 									"version": null
 								}
 							}],


### PR DESCRIPTION
For Outlook Mobile we support api-sets till 1.5 and after that we support ad hoc APIs from further api-sets. 

To let the same add-in work across platforms, we need to make sure that add-ins which mention higher API sets in their manifests, also work for mobile starting form 1.6. This change adds 1.13 to this list.