### PR TITLE
[RibbonApi] Update GA support for 1.1

### DIFF
--- a/mapping/requirements_officejs.json
+++ b/mapping/requirements_officejs.json
@@ -2572,6 +2572,11 @@
 						},
 						{
 							"name": "RibbonApi",
+							"apiVersion": "1.1",
+							"availability": "GA"
+						},
+						{
+							"name": "RibbonApi",
 							"apiVersion": "1.2",
 							"availability": "GA"
 						}
@@ -6067,11 +6072,6 @@
 						},
 						{
 							"name": "SharedRuntime",
-							"apiVersion": "1.1",
-							"availability": "GA"
-						},
-						{
-							"name": "RibbonApi",
 							"apiVersion": "1.1",
 							"availability": "GA"
 						}


### PR DESCRIPTION
- Excel Online: Add that 1.1 is supported
- PowerPoint Online: Remove entry indicating that 1.1 is supported