### PR TITLE
DevicePermissionService for Outlook Online

### DIFF
--- a/mapping/requirements_officejs.json
+++ b/mapping/requirements_officejs.json
@@ -7818,7 +7818,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "16.0.17705.15010",
+									"build": "15.20.7480.0",
 									"version": null
 								}
 							}],

--- a/mapping/requirements_officejs.json
+++ b/mapping/requirements_officejs.json
@@ -7812,7 +7812,18 @@
 								}
 							}],
 							"availability": "GA"
-						}						
+						},
+						{
+							"name": "DevicePermissionService",
+							"apiVersion": "1.1",
+							"supportedProductVersions": [{
+								"from": {
+									"build": "16.0.17705.15010",
+									"version": null
+								}
+							}],
+							"availability": "GA"
+						}
 					],
 					"supportedMethods": []
 				}


### PR DESCRIPTION
Update RequirementsSet to include DevicePermissionService for Outlook Online.

PR for WXP Online is merged
https://github.com/OfficeDev/Office-Js-Requirement-Sets/pull/129