### PR TITLE
RibbonApi 1.1 for Word and PowerPoint Online

### DIFF
--- a/mapping/requirements_officejs.json
+++ b/mapping/requirements_officejs.json
@@ -7818,7 +7818,7 @@
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{
 								"from": {
-									"build": "16.0.17705.15010",
+									"build": "15.20.7480.0",
 									"version": null
 								}
 							}],

--- a/mapping/requirements_officejs.json
+++ b/mapping/requirements_officejs.json
@@ -7812,7 +7812,18 @@
 								}
 							}],
 							"availability": "GA"
-						}						
+						},
+						{
+							"name": "DevicePermissionService",
+							"apiVersion": "1.1",
+							"supportedProductVersions": [{
+								"from": {
+									"build": "16.0.17705.15010",
+									"version": null
+								}
+							}],
+							"availability": "GA"
+						}
 					],
 					"supportedMethods": []
 				}

--- a/mapping/requirements_officejs.json
+++ b/mapping/requirements_officejs.json
@@ -4680,6 +4680,11 @@
 							"availability": "GA"
 						},
 						{
+							"name": "RibbonApi",
+							"apiVersion": "1.1",
+							"availability": "GA"
+						},
+						{
 							"name": "Selection",
 							"apiVersion": "1.1",
 							"availability": "GA"
@@ -6127,6 +6132,11 @@
 						{
 							"name": "PowerPointApi",
 							"apiVersion": "1.5",
+							"availability": "GA"
+						},
+						{
+							"name": "RibbonApi",
+							"apiVersion": "1.1",
 							"availability": "GA"
 						},
 						{


### PR DESCRIPTION
added addin commands enable disabled (Ribbon Api) support for Word & Powerpoint Online

https://learn.microsoft.com/en-us/javascript/api/requirement-sets/common/ribbon-api-requirement-sets?view=common-js-preview