### PR TITLE
Update RibbonApi 1.1 for Word and PowerPoint on Windows and Mac

### DIFF
--- a/mapping/requirements_officejs.json
+++ b/mapping/requirements_officejs.json
@@ -4013,6 +4013,17 @@
 								}
 							}],
 							"availability": "GA"
+						},
+						{
+							"name": "RibbonApi",
+							"apiVersion": "1.1",
+							"supportedProductVersions": [{
+								"from": {
+									"build": "16.57.105.0",
+									"version": null
+								}
+							}],
+							"availability": "GA"
 						}
 					],
 					"supportedMethods": [{
@@ -5292,6 +5303,17 @@
 								}
 							}],
 							"availability": "GA"
+						},
+						{
+							"name": "RibbonApi",
+							"apiVersion": "1.1",
+							"supportedProductVersions": [{
+								"from": {
+									"build": "16.0.14827.10000",
+									"version": null
+								}
+							}],
+							"availability": "GA"
 						}
 					],
 					"supportedMethods": [{
@@ -5950,6 +5972,17 @@
 								}
 							}],
 							"availability": "GA"
+						},
+						{
+							"name": "RibbonApi",
+							"apiVersion": "1.1",
+							"supportedProductVersions": [{
+								"from": {
+									"build": "16.57.105.0",
+									"version": null
+								}
+							}],
+							"availability": "GA"
 						}
 					],
 					"supportedMethods": [{
@@ -6461,6 +6494,17 @@
 							"supportedProductVersions": [{
 								"from": {
 									"build": "16.0.13127.20002",
+									"version": null
+								}
+							}],
+							"availability": "GA"
+						},
+						{
+							"name": "RibbonApi",
+							"apiVersion": "1.1",
+							"supportedProductVersions": [{
+								"from": {
+									"build": "16.0.14827.10000",
 									"version": null
 								}
 							}],


### PR DESCRIPTION
Updated RibbonApi1.1 support information for Word and PowerPoint on Windows and Mac.