### PR TITLE
Add 1.14 and 1.15 Requirement Set for New Outlook for Windows (OWA)

### DIFF
--- a/mapping/requirements_officejs.json
+++ b/mapping/requirements_officejs.json
@@ -8064,6 +8064,28 @@
 							"availability": "GA"
 						},
 						{
+							"name": "Mailbox",
+							"apiVersion": "1.14",
+							"supportedProductVersions": [{
+								"from": {
+									"build": "15.20.7480.0",
+									"version": null
+								}
+							}],
+							"availability": "GA"
+						},
+						{
+							"name": "Mailbox",
+							"apiVersion": "1.15",
+							"supportedProductVersions": [{
+								"from": {
+									"build": "15.20.8190.0",
+									"version": null
+								}
+							}],
+							"availability": "GA"
+						},
+						{
 							"name": "DevicePermissionService",
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{


### PR DESCRIPTION
Updating the SoT to include Mailbox 1.14 and 1.15