### PR TITLE
Add Mailbox 1.14 requirement set support for Outlook on Mac

### DIFF
--- a/mapping/requirements_officejs.json
+++ b/mapping/requirements_officejs.json
@@ -7749,6 +7749,17 @@
 							"availability": "GA"
 						},
 						{
+							"name": "Mailbox",
+							"apiVersion": "1.14",
+							"supportedProductVersions": [{
+								"from": {
+									"build": "15.20.7480.0",
+									"version": null
+								}
+							}],
+							"availability": "GA"
+						},
+						{
 							"name": "OpenBrowserWindowApi",
 							"apiVersion": "1.1",
 							"supportedProductVersions": [{


### PR DESCRIPTION
Mailbox requirement set 1.14 support has been recently enabled for Outlook on Mac, updating the Office-JS requirement set mapping file to reflect the same.